### PR TITLE
override 1: move customLine to front of status line

### DIFF
--- a/src/render/lines/project.ts
+++ b/src/render/lines/project.ts
@@ -18,6 +18,11 @@ export function renderProjectLine(ctx: RenderContext): string | null {
   const colors = ctx.config?.colors;
   const parts: string[] = [];
 
+  const customLine = display?.customLine;
+  if (customLine) {
+    parts.push(customColor(customLine, colors));
+  }
+
   if (display?.showModel !== false) {
     const model = formatModelName(getModelName(ctx.stdin), ctx.config?.display?.modelFormat, ctx.config?.display?.modelOverride);
     const providerLabel = getProviderLabel(ctx.stdin);
@@ -99,11 +104,6 @@ export function renderProjectLine(ctx: RenderContext): string | null {
   const costEstimate = renderCostEstimate(ctx);
   if (costEstimate) {
     parts.push(costEstimate);
-  }
-
-  const customLine = display?.customLine;
-  if (customLine) {
-    parts.push(customColor(customLine, colors));
   }
 
   if (parts.length === 0) {

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -31,6 +31,12 @@ export function renderSessionLine(ctx: RenderContext): string {
 
   const parts: string[] = [];
   const display = ctx.config?.display;
+
+  // Custom line (static user-defined text) — rendered first
+  const customLine = display?.customLine;
+  if (customLine) {
+    parts.push(customColor(customLine, colors));
+  }
   const contextValueMode = display?.contextValue ?? 'percent';
   const contextValue = formatContextValue(ctx, percent, contextValueMode);
   const contextValueDisplay = `${getContextColor(percent, colors)}${contextValue}${RESET}`;
@@ -226,12 +232,6 @@ export function renderSessionLine(ctx: RenderContext): string {
 
   if (ctx.extraLabel) {
     parts.push(label(ctx.extraLabel, colors));
-  }
-
-  // Custom line (static user-defined text)
-  const customLine = display?.customLine;
-  if (customLine) {
-    parts.push(customColor(customLine, colors));
   }
 
   let line = parts.join(' | ');


### PR DESCRIPTION
## Summary

- Moved `customLine` rendering to be the **first** segment in the project line (expanded layout)
- Moved `customLine` rendering to be the **first** segment in the session line (compact layout)

## Files modified

- `src/render/lines/project.ts` — customLine pushed to `parts[]` before model badge
- `src/render/session-line.ts` — customLine pushed to `parts[]` before model+context bar

## Build result

✅ `npx tsc --noEmit` passed with no errors

https://claude.ai/code/session_01BoBGrLdkPgGCrz1ShtsWPj