### PR TITLE
override 2: localize session duration label and format

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -131,12 +131,12 @@ export function formatSessionDuration(
   const ms = now() - sessionStart.getTime();
   const mins = Math.floor(ms / 60000);
 
-  if (mins < 1) return "<1m";
-  if (mins < 60) return `${mins}m`;
+  if (mins < 1) return "< 1 分鐘";
+  if (mins < 60) return `${mins} 分鐘`;
 
   const hours = Math.floor(mins / 60);
   const remainingMins = mins % 60;
-  return `${hours}h ${remainingMins}m`;
+  return `${hours} 小時 ${remainingMins} 分鐘`;
 }
 
 const scriptPath = fileURLToPath(import.meta.url);

--- a/src/render/lines/project.ts
+++ b/src/render/lines/project.ts
@@ -93,7 +93,7 @@ export function renderProjectLine(ctx: RenderContext): string | null {
   }
 
   if (display?.showDuration !== false && ctx.sessionDuration) {
-    parts.push(label(`⏱️  ${ctx.sessionDuration}`, colors));
+    parts.push(label(`⏱️ 執行時間：${ctx.sessionDuration}`, colors));
   }
 
   const costEstimate = renderCostEstimate(ctx);

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -216,7 +216,7 @@ export function renderSessionLine(ctx: RenderContext): string {
   }
 
   if (display?.showDuration !== false && ctx.sessionDuration) {
-    parts.push(label(`⏱️  ${ctx.sessionDuration}`, colors));
+    parts.push(label(`⏱️ 執行時間：${ctx.sessionDuration}`, colors));
   }
 
   const costEstimate = renderCostEstimate(ctx);


### PR DESCRIPTION
## Summary

- Added `執行時間：` prefix to the duration label (after ⏱️ emoji) in both expanded and compact layouts
- Replaced English duration format with Chinese units: `< 1 分鐘`, `N 分鐘`, `N 小時 M 分鐘`
- Duration format is not configurable via user config — modified `formatSessionDuration()` directly

## Files modified

- `src/render/lines/project.ts` — duration label prefix (expanded layout)
- `src/render/session-line.ts` — duration label prefix (compact layout)
- `src/index.ts` — `formatSessionDuration()` output format

## Build result

✅ `npx tsc --noEmit` passed with no errors

https://claude.ai/code/session_01BoBGrLdkPgGCrz1ShtsWPj