### PR TITLE
override 3: increase terminal width fallback to 120

### DIFF
--- a/src/utils/terminal.ts
+++ b/src/utils/terminal.ts
@@ -1,4 +1,4 @@
-export const UNKNOWN_TERMINAL_WIDTH = 40;
+export const UNKNOWN_TERMINAL_WIDTH = 120;
 
 // Returns a progress bar width scaled to the current terminal width.
 // Wide (>=100): 10, Medium (60-99): 6, Narrow (<60): 4.


### PR DESCRIPTION
## Summary

- Changed `UNKNOWN_TERMINAL_WIDTH` from `40` to `120` in `src/utils/terminal.ts`
- Terminal width fallback is not configurable via user config — modified the constant directly
- Prevents excessive line truncation when running in pipe mode

## Files modified

- `src/utils/terminal.ts` — `UNKNOWN_TERMINAL_WIDTH` constant value

## Build result

✅ `npx tsc --noEmit` passed with no errors

https://claude.ai/code/session_01BoBGrLdkPgGCrz1ShtsWPj