### PR TITLE
override 4: add weekly usage as a separate HUD line

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -17,7 +17,7 @@ export type ContextValueMode = 'percent' | 'tokens' | 'remaining' | 'both';
  *   short:   Strip context suffix AND "Claude " prefix (e.g. "Opus 4.6")
  */
 export type ModelFormatMode = 'full' | 'compact' | 'short';
-export type HudElement = 'project' | 'context' | 'usage' | 'memory' | 'environment' | 'tools' | 'agents' | 'todos';
+export type HudElement = 'project' | 'context' | 'usage' | 'weeklyUsage' | 'memory' | 'environment' | 'tools' | 'agents' | 'todos';
 export type HudColorName =
   | 'dim'
   | 'red'
@@ -47,8 +47,9 @@ export interface HudColorOverrides {
 
 export const DEFAULT_ELEMENT_ORDER: HudElement[] = [
   'project',
-  'context',
   'usage',
+  'weeklyUsage',
+  'context',
   'memory',
   'environment',
   'tools',

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -11,6 +11,7 @@ import {
   renderGitFilesLine,
   renderEnvironmentLine,
   renderUsageLine,
+  renderWeeklyUsageLine,
   renderMemoryLine,
   renderSessionTokensLine,
 } from './lines/index.js';
@@ -349,6 +350,8 @@ function renderElementLine(ctx: RenderContext, element: HudElement): string | nu
       return renderIdentityLine(ctx);
     case 'usage':
       return renderUsageLine(ctx);
+    case 'weeklyUsage':
+      return renderWeeklyUsageLine(ctx);
     case 'memory':
       return renderMemoryLine(ctx);
     case 'environment':

--- a/src/render/lines/index.ts
+++ b/src/render/lines/index.ts
@@ -2,5 +2,6 @@ export { renderIdentityLine } from './identity.js';
 export { renderProjectLine, renderGitFilesLine } from './project.js';
 export { renderEnvironmentLine } from './environment.js';
 export { renderUsageLine } from './usage.js';
+export { renderWeeklyUsageLine } from './weekly-usage.js';
 export { renderMemoryLine } from './memory.js';
 export { renderSessionTokensLine } from './session-tokens.js';

--- a/src/render/lines/usage.ts
+++ b/src/render/lines/usage.ts
@@ -41,20 +41,10 @@ export function renderUsageLine(ctx: RenderContext): string | null {
   }
 
   const usageBarEnabled = display?.usageBarEnabled ?? true;
-  const sevenDayThreshold = display?.sevenDayThreshold ?? 80;
   const barWidth = getAdaptiveBarWidth();
 
-  if (fiveHour === null && sevenDay !== null) {
-    const weeklyOnlyPart = formatUsageWindowPart({
-      label: t("label.weekly"),
-      percent: sevenDay,
-      resetAt: ctx.usageData.sevenDayResetAt,
-      colors,
-      usageBarEnabled,
-      barWidth,
-      forceLabel: true,
-    });
-    return `${usageLabel} ${weeklyOnlyPart}`;
+  if (fiveHour === null) {
+    return null;
   }
 
   const fiveHourPart = formatUsageWindowPart({
@@ -65,19 +55,6 @@ export function renderUsageLine(ctx: RenderContext): string | null {
     usageBarEnabled,
     barWidth,
   });
-
-  if (sevenDay !== null && sevenDay >= sevenDayThreshold) {
-    const sevenDayPart = formatUsageWindowPart({
-      label: t("label.weekly"),
-      percent: sevenDay,
-      resetAt: ctx.usageData.sevenDayResetAt,
-      colors,
-      usageBarEnabled,
-      barWidth,
-      forceLabel: true,
-    });
-    return `${usageLabel} ${fiveHourPart} | ${sevenDayPart}`;
-  }
 
   return `${usageLabel} ${fiveHourPart}`;
 }

--- a/src/render/lines/weekly-usage.ts
+++ b/src/render/lines/weekly-usage.ts
@@ -1,0 +1,77 @@
+import type { RenderContext } from "../../types.js";
+import { getProviderLabel } from "../../stdin.js";
+import { label, getQuotaColor, quotaBar, RESET } from "../colors.js";
+import { getAdaptiveBarWidth } from "../../utils/terminal.js";
+import { t } from "../../i18n/index.js";
+
+export function renderWeeklyUsageLine(ctx: RenderContext): string | null {
+  const display = ctx.config?.display;
+  const colors = ctx.config?.colors;
+
+  if (display?.showUsage === false) {
+    return null;
+  }
+
+  if (!ctx.usageData) {
+    return null;
+  }
+
+  if (getProviderLabel(ctx.stdin)) {
+    return null;
+  }
+
+  const sevenDay = ctx.usageData.sevenDay;
+  if (sevenDay === null) {
+    return null;
+  }
+
+  const weeklyLabel = label(t("label.weekly"), colors);
+  const barWidth = getAdaptiveBarWidth();
+  const usageBarEnabled = display?.usageBarEnabled ?? true;
+  const usageDisplay = formatUsagePercent(sevenDay, colors);
+  const reset = formatResetTime(ctx.usageData.sevenDayResetAt);
+
+  if (usageBarEnabled) {
+    const body = reset
+      ? `${quotaBar(sevenDay, barWidth, colors)} ${usageDisplay} (${t("format.resetsIn")} ${reset})`
+      : `${quotaBar(sevenDay, barWidth, colors)} ${usageDisplay}`;
+    return `${weeklyLabel} ${body}`;
+  }
+
+  return reset
+    ? `${weeklyLabel} ${usageDisplay} (${t("format.resetsIn")} ${reset})`
+    : `${weeklyLabel} ${usageDisplay}`;
+}
+
+function formatUsagePercent(
+  percent: number | null,
+  colors?: RenderContext["config"]["colors"],
+): string {
+  if (percent === null) {
+    return label("--", colors);
+  }
+  const color = getQuotaColor(percent, colors);
+  return `${color}${percent}%${RESET}`;
+}
+
+function formatResetTime(resetAt: Date | null): string {
+  if (!resetAt) return "";
+  const now = new Date();
+  const diffMs = resetAt.getTime() - now.getTime();
+  if (diffMs <= 0) return "";
+
+  const diffMins = Math.ceil(diffMs / 60000);
+  if (diffMins < 60) return `${diffMins}m`;
+
+  const hours = Math.floor(diffMins / 60);
+  const mins = diffMins % 60;
+
+  if (hours >= 24) {
+    const days = Math.floor(hours / 24);
+    const remHours = hours % 24;
+    if (remHours > 0) return `${days}d ${remHours}h`;
+    return `${days}d`;
+  }
+
+  return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`;
+}


### PR DESCRIPTION
## Summary

- Added `weeklyUsage` as a new HUD element type in `HudElement`
- Created `renderWeeklyUsageLine` — follows same bar/color/layout pattern as the original five-hour usage
- Removed weekly usage rendering from the original `usage` element (now five-hour only)
- Registered `weeklyUsage` in the render coordinator's element-to-renderer mapping
- Updated default element order to `[project, usage, weeklyUsage, context, ...]` — placing weekly after usage and before context, which naturally breaks the context+usage same-line combining

## Files modified

- `src/config.ts` — `HudElement` type + `DEFAULT_ELEMENT_ORDER`
- `src/render/lines/weekly-usage.ts` — new render function (created)
- `src/render/lines/usage.ts` — removed weekly usage rendering
- `src/render/lines/index.ts` — barrel export for new module
- `src/render/index.ts` — `weeklyUsage` case in `renderElementLine`

## Build result

✅ `npx tsc --noEmit` passed with no errors

https://claude.ai/code/session_01BoBGrLdkPgGCrz1ShtsWPj