### PR TITLE
override 5: change bar characters from blocks to dots

### DIFF
--- a/src/render/colors.ts
+++ b/src/render/colors.ts
@@ -134,7 +134,7 @@ export function quotaBar(percent: number, width: number = 10, colors?: Partial<H
   const filled = Math.round((safePercent / 100) * safeWidth);
   const empty = safeWidth - filled;
   const color = getQuotaColor(safePercent, colors);
-  return `${color}${'█'.repeat(filled)}${DIM}${'░'.repeat(empty)}${RESET}`;
+  return `${color}${'●'.repeat(filled)}${DIM}${'○'.repeat(empty)}${RESET}`;
 }
 
 export function coloredBar(percent: number, width: number = 10, colors?: Partial<HudColorOverrides>): string {
@@ -143,5 +143,5 @@ export function coloredBar(percent: number, width: number = 10, colors?: Partial
   const filled = Math.round((safePercent / 100) * safeWidth);
   const empty = safeWidth - filled;
   const color = getContextColor(safePercent, colors);
-  return `${color}${'█'.repeat(filled)}${DIM}${'░'.repeat(empty)}${RESET}`;
+  return `${color}${'●'.repeat(filled)}${DIM}${'○'.repeat(empty)}${RESET}`;
 }


### PR DESCRIPTION
## Summary

- Replaced filled bar character `█` with `●` in both `quotaBar()` and `coloredBar()`
- Replaced empty bar character `░` with `○` in both functions
- Color scheme fully preserved — only the characters changed
- Bar characters are not configurable via user config

## Files modified

- `src/render/colors.ts` — bar character replacements in `quotaBar()` and `coloredBar()`

## Build result

✅ `npx tsc --noEmit` passed with no errors

https://claude.ai/code/session_01BoBGrLdkPgGCrz1ShtsWPj