### PR TITLE
override 6: add Traditional Chinese (Taiwan) zh-TW locale

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -182,7 +182,7 @@ function validateContextValue(value: unknown): value is ContextValueMode {
 }
 
 function validateLanguage(value: unknown): value is Language {
-  return value === 'en' || value === 'zh';
+  return value === 'en' || value === 'zh' || value === 'zh-TW';
 }
 
 function validateModelFormat(value: unknown): value is ModelFormatMode {

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,10 +1,11 @@
 import type { Language, MessageKey, Messages } from "./types.js";
 import { en } from "./en.js";
 import { zh } from "./zh.js";
+import { zhTW } from "./zh-TW.js";
 
 export type { Language, MessageKey, Messages };
 
-const locales: Record<Language, Messages> = { en, zh };
+const locales: Record<Language, Messages> = { en, zh, "zh-TW": zhTW };
 
 let currentLanguage: Language = "en";
 

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -24,4 +24,4 @@ export type MessageKey =
 
 export type Messages = Record<MessageKey, string>;
 
-export type Language = "en" | "zh";
+export type Language = "en" | "zh" | "zh-TW";

--- a/src/i18n/zh-TW.ts
+++ b/src/i18n/zh-TW.ts
@@ -1,0 +1,30 @@
+import type { Messages } from "./types.js";
+
+export const zhTW: Messages = {
+  // Labels
+  "label.context": "上下文佔用",
+  "label.usage": "五小時上限",
+  "label.weekly": "每週使用量",
+  "label.approxRam": "記憶體用量",
+  "label.rules": "規則",
+  "label.hooks": "hooks",
+  "label.estimatedCost": "估算",
+  "label.cost": "費用",
+
+  // Status
+  "status.limitReached": "已達上限",
+  "status.allTodosComplete": "全部完成",
+
+  // Format
+  "format.resets": "重置於",
+  "format.resetsIn": "重置剩餘",
+  "format.in": "輸入",
+  "format.cache": "快取",
+  "format.out": "輸出",
+  "format.tokPerSec": "tok/s",
+
+  // Init
+  "init.initializing": "[claude-hud] 正在初始化...",
+  "init.macosNote":
+    "[claude-hud] 注意：在 macOS 上，您可能需要重啟 Claude Code 才能顯示 HUD。",
+};


### PR DESCRIPTION
## Summary

- Added `zh-TW` to the `Language` type definition
- Created `src/i18n/zh-TW.ts` with Taiwan-specific translations (e.g. `五小時上限`, `每週使用量`, `上下文佔用`, `快取`)
- Registered `zh-TW` in the locale registry (`i18n/index.ts`)
- Updated `validateLanguage()` in `config.ts` to accept `zh-TW`

## Files modified

- `src/i18n/types.ts` — `Language` type union
- `src/i18n/zh-TW.ts` — new locale file (created)
- `src/i18n/index.ts` — locale registry
- `src/config.ts` — language validation

## Build result

✅ `npx tsc --noEmit` passed with no errors

https://claude.ai/code/session_01BoBGrLdkPgGCrz1ShtsWPj