### PR TITLE
override 7: format percentages and bar spacing

### DIFF
--- a/src/render/lines/identity.ts
+++ b/src/render/lines/identity.ts
@@ -31,8 +31,8 @@ export function renderIdentityLine(ctx: RenderContext): string {
 
   let line =
     display?.showContextBar !== false
-      ? `${label(t("label.context"), colors)} ${coloredBar(percent, getAdaptiveBarWidth(), colors)} ${contextValueDisplay}`
-      : `${label(t("label.context"), colors)} ${contextValueDisplay}`;
+      ? `${label(t("label.context"), colors)}  ${coloredBar(percent, getAdaptiveBarWidth(), colors)} ${contextValueDisplay}`
+      : `${label(t("label.context"), colors)}  ${contextValueDisplay}`;
 
   if (display?.showTokenBreakdown !== false && percent >= 85) {
     const usage = ctx.stdin.context_window?.current_usage;
@@ -79,14 +79,14 @@ function formatContextValue(
 
   if (mode === "both") {
     if (size > 0) {
-      return `${percent}% (${formatTokens(totalTokens)}/${formatTokens(size)})`;
+      return `${String(percent).padStart(3)} % (${formatTokens(totalTokens)}/${formatTokens(size)})`;
     }
-    return `${percent}%`;
+    return `${String(percent).padStart(3)} %`;
   }
 
   if (mode === "remaining") {
-    return `${Math.max(0, 100 - percent)}%`;
+    return `${String(Math.max(0, 100 - percent)).padStart(3)} %`;
   }
 
-  return `${percent}%`;
+  return `${String(percent).padStart(3)} %`;
 }

--- a/src/render/lines/usage.ts
+++ b/src/render/lines/usage.ts
@@ -54,7 +54,7 @@ export function renderUsageLine(ctx: RenderContext): string | null {
       barWidth,
       forceLabel: true,
     });
-    return `${usageLabel} ${weeklyOnlyPart}`;
+    return `${usageLabel}  ${weeklyOnlyPart}`;
   }
 
   const fiveHourPart = formatUsageWindowPart({
@@ -76,10 +76,10 @@ export function renderUsageLine(ctx: RenderContext): string | null {
       barWidth,
       forceLabel: true,
     });
-    return `${usageLabel} ${fiveHourPart} | ${sevenDayPart}`;
+    return `${usageLabel}  ${fiveHourPart} | ${sevenDayPart}`;
   }
 
-  return `${usageLabel} ${fiveHourPart}`;
+  return `${usageLabel}  ${fiveHourPart}`;
 }
 
 function formatUsagePercent(
@@ -90,7 +90,7 @@ function formatUsagePercent(
     return label("--", colors);
   }
   const color = getQuotaColor(percent, colors);
-  return `${color}${percent}%${RESET}`;
+  return `${color}${String(percent).padStart(3)} %${RESET}`;
 }
 
 function formatUsageWindowPart({
@@ -118,12 +118,12 @@ function formatUsageWindowPart({
     const body = reset
       ? `${quotaBar(percent ?? 0, barWidth, colors)} ${usageDisplay} (${t("format.resetsIn")} ${reset})`
       : `${quotaBar(percent ?? 0, barWidth, colors)} ${usageDisplay}`;
-    return forceLabel ? `${styledLabel} ${body}` : body;
+    return forceLabel ? `${styledLabel}  ${body}` : body;
   }
 
   return reset
-    ? `${styledLabel} ${usageDisplay} (${t("format.resetsIn")} ${reset})`
-    : `${styledLabel} ${usageDisplay}`;
+    ? `${styledLabel}  ${usageDisplay} (${t("format.resetsIn")} ${reset})`
+    : `${styledLabel}  ${usageDisplay}`;
 }
 
 function formatResetTime(resetAt: Date | null): string {

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -188,10 +188,10 @@ export function renderSessionLine(ctx: RenderContext): string {
               barWidth,
               forceLabel: true,
             });
-            parts.push(`${label(t('label.usage'), colors)} ${fiveHourPart}`);
+            parts.push(`${label(t('label.usage'), colors)}  ${fiveHourPart}`);
             parts.push(sevenDayPart);
           } else {
-            parts.push(`${label(t('label.usage'), colors)} ${fiveHourPart}`);
+            parts.push(`${label(t('label.usage'), colors)}  ${fiveHourPart}`);
           }
         }
       }
@@ -272,16 +272,16 @@ function formatContextValue(ctx: RenderContext, percent: number, mode: 'percent'
 
   if (mode === 'both') {
     if (size > 0) {
-      return `${percent}% (${formatTokens(totalTokens)}/${formatTokens(size)})`;
+      return `${String(percent).padStart(3)} % (${formatTokens(totalTokens)}/${formatTokens(size)})`;
     }
-    return `${percent}%`;
+    return `${String(percent).padStart(3)} %`;
   }
 
   if (mode === 'remaining') {
-    return `${Math.max(0, 100 - percent)}%`;
+    return `${String(Math.max(0, 100 - percent)).padStart(3)} %`;
   }
 
-  return `${percent}%`;
+  return `${String(percent).padStart(3)} %`;
 }
 
 function formatUsagePercent(percent: number | null, colors?: RenderContext['config']['colors']): string {
@@ -289,7 +289,7 @@ function formatUsagePercent(percent: number | null, colors?: RenderContext['conf
     return label('--', colors);
   }
   const color = getQuotaColor(percent, colors);
-  return `${color}${percent}%${RESET}`;
+  return `${color}${String(percent).padStart(3)} %${RESET}`;
 }
 
 function formatUsageWindowPart({
@@ -317,12 +317,12 @@ function formatUsageWindowPart({
     const body = reset
       ? `${quotaBar(percent ?? 0, barWidth, colors)} ${usageDisplay} (${reset} / ${windowLabel})`
       : `${quotaBar(percent ?? 0, barWidth, colors)} ${usageDisplay}`;
-    return forceLabel ? `${styledLabel} ${body}` : body;
+    return forceLabel ? `${styledLabel}  ${body}` : body;
   }
 
   return reset
-    ? `${styledLabel} ${usageDisplay} (${t('format.resetsIn')} ${reset})`
-    : `${styledLabel} ${usageDisplay}`;
+    ? `${styledLabel}  ${usageDisplay} (${t('format.resetsIn')} ${reset})`
+    : `${styledLabel}  ${usageDisplay}`;
 }
 
 function formatResetTime(resetAt: Date | null): string {


### PR DESCRIPTION
## Summary

- **Percentage format**: padded to 3 characters with leading spaces, followed by ` %` (e.g. `  1 %`, ` 50 %`, `100 %`)
- **Bar spacing**: exactly 2 spaces between label and bar, 1 space between bar and percentage
- Applied to five-hour usage, weekly usage, and context percentage displays
- Applied in both expanded and compact layouts

## Files modified

- `src/render/lines/identity.ts` — context percentage format + label-bar spacing
- `src/render/lines/usage.ts` — usage percentage format + label-bar spacing
- `src/render/session-line.ts` — usage + context percentage format + label-bar spacing (compact)

## Build result

✅ `npx tsc --noEmit` passed with no errors

https://claude.ai/code/session_01BoBGrLdkPgGCrz1ShtsWPj