### PR TITLE
override 8: format five-hour reset time as clock time

### DIFF
--- a/src/render/lines/usage.ts
+++ b/src/render/lines/usage.ts
@@ -26,9 +26,12 @@ export function renderUsageLine(ctx: RenderContext): string | null {
   if (isLimitReached(ctx.usageData)) {
     const resetTime =
       ctx.usageData.fiveHour === 100
-        ? formatResetTime(ctx.usageData.fiveHourResetAt)
+        ? formatFiveHourResetClock(ctx.usageData.fiveHourResetAt)
         : formatResetTime(ctx.usageData.sevenDayResetAt);
-    return `${usageLabel} ${critical(`⚠ ${t("status.limitReached")}${resetTime ? ` (${t("format.resets")} ${resetTime})` : ""}`, colors)}`;
+    const resetSuffix = ctx.usageData.fiveHour === 100
+      ? (resetTime ? ` (${resetTime})` : "")
+      : (resetTime ? ` (${t("format.resets")} ${resetTime})` : "");
+    return `${usageLabel} ${critical(`⚠ ${t("status.limitReached")}${resetSuffix}`, colors)}`;
   }
 
   const threshold = display?.usageThreshold ?? 0;
@@ -61,6 +64,7 @@ export function renderUsageLine(ctx: RenderContext): string | null {
     label: "5h",
     percent: fiveHour,
     resetAt: ctx.usageData.fiveHourResetAt,
+    resetDisplay: formatFiveHourResetClock(ctx.usageData.fiveHourResetAt),
     colors,
     usageBarEnabled,
     barWidth,
@@ -97,6 +101,7 @@ function formatUsageWindowPart({
   label: windowLabel,
   percent,
   resetAt,
+  resetDisplay,
   colors,
   usageBarEnabled,
   barWidth,
@@ -105,24 +110,31 @@ function formatUsageWindowPart({
   label: string;
   percent: number | null;
   resetAt: Date | null;
+  resetDisplay?: string;
   colors?: RenderContext["config"]["colors"];
   usageBarEnabled: boolean;
   barWidth: number;
   forceLabel?: boolean;
 }): string {
   const usageDisplay = formatUsagePercent(percent, colors);
-  const reset = formatResetTime(resetAt);
   const styledLabel = label(windowLabel, colors);
+  let resetText = '';
+  if (resetDisplay) {
+    resetText = resetDisplay;
+  } else {
+    const reset = formatResetTime(resetAt);
+    if (reset) resetText = `${t("format.resetsIn")} ${reset}`;
+  }
 
   if (usageBarEnabled) {
-    const body = reset
-      ? `${quotaBar(percent ?? 0, barWidth, colors)} ${usageDisplay} (${t("format.resetsIn")} ${reset})`
+    const body = resetText
+      ? `${quotaBar(percent ?? 0, barWidth, colors)} ${usageDisplay} (${resetText})`
       : `${quotaBar(percent ?? 0, barWidth, colors)} ${usageDisplay}`;
     return forceLabel ? `${styledLabel} ${body}` : body;
   }
 
-  return reset
-    ? `${styledLabel} ${usageDisplay} (${t("format.resetsIn")} ${reset})`
+  return resetText
+    ? `${styledLabel} ${usageDisplay} (${resetText})`
     : `${styledLabel} ${usageDisplay}`;
 }
 
@@ -146,4 +158,13 @@ function formatResetTime(resetAt: Date | null): string {
   }
 
   return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`;
+}
+
+function formatFiveHourResetClock(resetAt: Date | null): string {
+  if (!resetAt) return '';
+  const now = new Date();
+  if (resetAt.getTime() <= now.getTime()) return '即將重置';
+  const hh = String(resetAt.getHours()).padStart(2, '0');
+  const mm = String(resetAt.getMinutes()).padStart(2, '0');
+  return `於 ${hh}:${mm} 重置`;
 }

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -145,9 +145,12 @@ export function renderSessionLine(ctx: RenderContext): string {
   if (display?.showUsage !== false && ctx.usageData && !providerLabel) {
     if (isLimitReached(ctx.usageData)) {
       const resetTime = ctx.usageData.fiveHour === 100
-        ? formatResetTime(ctx.usageData.fiveHourResetAt)
+        ? formatFiveHourResetClock(ctx.usageData.fiveHourResetAt)
         : formatResetTime(ctx.usageData.sevenDayResetAt);
-      parts.push(critical(`⚠ ${t('status.limitReached')}${resetTime ? ` (${t('format.resets')} ${resetTime})` : ''}`, colors));
+      const resetSuffix = ctx.usageData.fiveHour === 100
+        ? (resetTime ? ` (${resetTime})` : '')
+        : (resetTime ? ` (${t('format.resets')} ${resetTime})` : '');
+      parts.push(critical(`⚠ ${t('status.limitReached')}${resetSuffix}`, colors));
     } else {
       const usageThreshold = display?.usageThreshold ?? 0;
       const fiveHour = ctx.usageData.fiveHour;
@@ -172,6 +175,7 @@ export function renderSessionLine(ctx: RenderContext): string {
             label: '5h',
             percent: fiveHour,
             resetAt: ctx.usageData.fiveHourResetAt,
+            resetDisplay: formatFiveHourResetClock(ctx.usageData.fiveHourResetAt),
             colors,
             usageBarEnabled,
             barWidth,
@@ -296,6 +300,7 @@ function formatUsageWindowPart({
   label: windowLabel,
   percent,
   resetAt,
+  resetDisplay,
   colors,
   usageBarEnabled,
   barWidth,
@@ -304,24 +309,39 @@ function formatUsageWindowPart({
   label: string;
   percent: number | null;
   resetAt: Date | null;
+  resetDisplay?: string;
   colors?: RenderContext['config']['colors'];
   usageBarEnabled: boolean;
   barWidth: number;
   forceLabel?: boolean;
 }): string {
   const usageDisplay = formatUsagePercent(percent, colors);
-  const reset = formatResetTime(resetAt);
   const styledLabel = label(windowLabel, colors);
+  let resetText = '';
+  if (resetDisplay) {
+    resetText = resetDisplay;
+  } else {
+    const reset = formatResetTime(resetAt);
+    if (reset) resetText = `${reset} / ${windowLabel}`;
+  }
 
   if (usageBarEnabled) {
-    const body = reset
-      ? `${quotaBar(percent ?? 0, barWidth, colors)} ${usageDisplay} (${reset} / ${windowLabel})`
+    const body = resetText
+      ? `${quotaBar(percent ?? 0, barWidth, colors)} ${usageDisplay} (${resetText})`
       : `${quotaBar(percent ?? 0, barWidth, colors)} ${usageDisplay}`;
     return forceLabel ? `${styledLabel} ${body}` : body;
   }
 
-  return reset
-    ? `${styledLabel} ${usageDisplay} (${t('format.resetsIn')} ${reset})`
+  if (!resetDisplay) {
+    const reset = formatResetTime(resetAt);
+    const fallbackReset = reset ? `${t('format.resetsIn')} ${reset}` : '';
+    return fallbackReset
+      ? `${styledLabel} ${usageDisplay} (${fallbackReset})`
+      : `${styledLabel} ${usageDisplay}`;
+  }
+
+  return resetText
+    ? `${styledLabel} ${usageDisplay} (${resetText})`
     : `${styledLabel} ${usageDisplay}`;
 }
 
@@ -345,4 +365,13 @@ function formatResetTime(resetAt: Date | null): string {
   }
 
   return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`;
+}
+
+function formatFiveHourResetClock(resetAt: Date | null): string {
+  if (!resetAt) return '';
+  const now = new Date();
+  if (resetAt.getTime() <= now.getTime()) return '即將重置';
+  const hh = String(resetAt.getHours()).padStart(2, '0');
+  const mm = String(resetAt.getMinutes()).padStart(2, '0');
+  return `於 ${hh}:${mm} 重置`;
 }


### PR DESCRIPTION
## Summary

- Added `formatFiveHourResetClock()` function that shows actual clock time instead of countdown
- Before reset: `於 HH:MM 重置` (24-hour format, zero-padded)
- At or past reset: `即將重置`
- No data: empty string
- Modified `formatUsageWindowPart` in both files to accept optional `resetDisplay` parameter
- Weekly reset formatting remains unchanged (countdown style)

## Files modified

- `src/render/lines/usage.ts` — five-hour clock format + `resetDisplay` param in expanded layout
- `src/render/session-line.ts` — five-hour clock format + `resetDisplay` param in compact layout

## Build result

✅ `npx tsc --noEmit` passed with no errors

https://claude.ai/code/session_01BoBGrLdkPgGCrz1ShtsWPj