### PR TITLE
override 10: add prefix to environment info line

### DIFF
--- a/src/render/lines/environment.ts
+++ b/src/render/lines/environment.ts
@@ -37,5 +37,5 @@ export function renderEnvironmentLine(ctx: RenderContext): string | null {
     return null;
   }
 
-  return label(parts.join(" | "), ctx.config?.colors);
+  return label(`參考：${parts.join(" | ")}`, ctx.config?.colors);
 }


### PR DESCRIPTION
## Summary

- Added `參考：` prefix before environment info content (rules, hooks, CLAUDE.md, MCPs counts)

## Files modified

- `src/render/lines/environment.ts` — prefix added to the `label()` output

## Build result

✅ `npx tsc --noEmit` passed with no errors

https://claude.ai/code/session_01BoBGrLdkPgGCrz1ShtsWPj