### PR TITLE
override 11: always show usage bar when limit is reached

### DIFF
--- a/src/render/lines/usage.ts
+++ b/src/render/lines/usage.ts
@@ -1,7 +1,6 @@
 import type { RenderContext } from "../../types.js";
-import { isLimitReached } from "../../types.js";
 import { getProviderLabel } from "../../stdin.js";
-import { critical, label, getQuotaColor, quotaBar, RESET } from "../colors.js";
+import { label, getQuotaColor, quotaBar, RESET } from "../colors.js";
 import { getAdaptiveBarWidth } from "../../utils/terminal.js";
 import { t } from "../../i18n/index.js";
 
@@ -22,14 +21,6 @@ export function renderUsageLine(ctx: RenderContext): string | null {
   }
 
   const usageLabel = label(t("label.usage"), colors);
-
-  if (isLimitReached(ctx.usageData)) {
-    const resetTime =
-      ctx.usageData.fiveHour === 100
-        ? formatResetTime(ctx.usageData.fiveHourResetAt)
-        : formatResetTime(ctx.usageData.sevenDayResetAt);
-    return `${usageLabel} ${critical(`⚠ ${t("status.limitReached")}${resetTime ? ` (${t("format.resets")} ${resetTime})` : ""}`, colors)}`;
-  }
 
   const threshold = display?.usageThreshold ?? 0;
   const fiveHour = ctx.usageData.fiveHour;

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -1,8 +1,7 @@
 import type { RenderContext } from '../types.js';
-import { isLimitReached } from '../types.js';
 import { getContextPercent, getBufferedPercent, getModelName, formatModelName, getProviderLabel, getTotalTokens } from '../stdin.js';
 import { getOutputSpeed } from '../speed-tracker.js';
-import { coloredBar, critical, git as gitColor, gitBranch as gitBranchColor, label, model as modelColor, project as projectColor, getContextColor, getQuotaColor, quotaBar, custom as customColor, RESET } from './colors.js';
+import { coloredBar, git as gitColor, gitBranch as gitBranchColor, label, model as modelColor, project as projectColor, getContextColor, getQuotaColor, quotaBar, custom as customColor, RESET } from './colors.js';
 import { getAdaptiveBarWidth } from '../utils/terminal.js';
 import { renderCostEstimate } from './lines/cost.js';
 import { t } from '../i18n/index.js';
@@ -143,21 +142,37 @@ export function renderSessionLine(ctx: RenderContext): string {
 
   // Usage limits display (shown when enabled in config, respects usageThreshold)
   if (display?.showUsage !== false && ctx.usageData && !providerLabel) {
-    if (isLimitReached(ctx.usageData)) {
-      const resetTime = ctx.usageData.fiveHour === 100
-        ? formatResetTime(ctx.usageData.fiveHourResetAt)
-        : formatResetTime(ctx.usageData.sevenDayResetAt);
-      parts.push(critical(`⚠ ${t('status.limitReached')}${resetTime ? ` (${t('format.resets')} ${resetTime})` : ''}`, colors));
-    } else {
-      const usageThreshold = display?.usageThreshold ?? 0;
-      const fiveHour = ctx.usageData.fiveHour;
-      const sevenDay = ctx.usageData.sevenDay;
-      const effectiveUsage = Math.max(fiveHour ?? 0, sevenDay ?? 0);
+    const usageThreshold = display?.usageThreshold ?? 0;
+    const fiveHour = ctx.usageData.fiveHour;
+    const sevenDay = ctx.usageData.sevenDay;
+    const effectiveUsage = Math.max(fiveHour ?? 0, sevenDay ?? 0);
 
-      if (effectiveUsage >= usageThreshold) {
-        const usageBarEnabled = display?.usageBarEnabled ?? true;
-        if (fiveHour === null && sevenDay !== null) {
-          const weeklyOnlyPart = formatUsageWindowPart({
+    if (effectiveUsage >= usageThreshold) {
+      const usageBarEnabled = display?.usageBarEnabled ?? true;
+      if (fiveHour === null && sevenDay !== null) {
+        const weeklyOnlyPart = formatUsageWindowPart({
+          label: t('label.weekly'),
+          percent: sevenDay,
+          resetAt: ctx.usageData.sevenDayResetAt,
+          colors,
+          usageBarEnabled,
+          barWidth,
+          forceLabel: true,
+        });
+        parts.push(weeklyOnlyPart);
+      } else {
+        const fiveHourPart = formatUsageWindowPart({
+          label: '5h',
+          percent: fiveHour,
+          resetAt: ctx.usageData.fiveHourResetAt,
+          colors,
+          usageBarEnabled,
+          barWidth,
+        });
+
+        const sevenDayThreshold = display?.sevenDayThreshold ?? 80;
+        if (sevenDay !== null && sevenDay >= sevenDayThreshold) {
+          const sevenDayPart = formatUsageWindowPart({
             label: t('label.weekly'),
             percent: sevenDay,
             resetAt: ctx.usageData.sevenDayResetAt,
@@ -166,33 +181,10 @@ export function renderSessionLine(ctx: RenderContext): string {
             barWidth,
             forceLabel: true,
           });
-          parts.push(weeklyOnlyPart);
+          parts.push(`${label(t('label.usage'), colors)} ${fiveHourPart}`);
+          parts.push(sevenDayPart);
         } else {
-          const fiveHourPart = formatUsageWindowPart({
-            label: '5h',
-            percent: fiveHour,
-            resetAt: ctx.usageData.fiveHourResetAt,
-            colors,
-            usageBarEnabled,
-            barWidth,
-          });
-
-          const sevenDayThreshold = display?.sevenDayThreshold ?? 80;
-          if (sevenDay !== null && sevenDay >= sevenDayThreshold) {
-            const sevenDayPart = formatUsageWindowPart({
-              label: t('label.weekly'),
-              percent: sevenDay,
-              resetAt: ctx.usageData.sevenDayResetAt,
-              colors,
-              usageBarEnabled,
-              barWidth,
-              forceLabel: true,
-            });
-            parts.push(`${label(t('label.usage'), colors)} ${fiveHourPart}`);
-            parts.push(sevenDayPart);
-          } else {
-            parts.push(`${label(t('label.usage'), colors)} ${fiveHourPart}`);
-          }
+          parts.push(`${label(t('label.usage'), colors)} ${fiveHourPart}`);
         }
       }
     }


### PR DESCRIPTION
## Summary

- Removed the `isLimitReached` special branch in expanded layout (`usage.ts`) that replaced the bar with `⚠ Limit reached`
- Removed the `isLimitReached` special branch in compact layout (`session-line.ts`) with the same effect
- The bar now continues to display at 100% naturally when rate limit is reached
- Cleaned up unused `critical` and `isLimitReached` imports

## Files modified

- `src/render/lines/usage.ts` — removed limit-reached branch + unused imports
- `src/render/session-line.ts` — removed limit-reached branch + unused imports

## Build result

✅ `npx tsc --noEmit` passed with no errors

https://claude.ai/code/session_01BoBGrLdkPgGCrz1ShtsWPj