### PR TITLE
override 2: localize session duration label and format

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -131,12 +131,12 @@ export function formatSessionDuration(
   const ms = now() - sessionStart.getTime();
   const mins = Math.floor(ms / 60000);
 
-  if (mins < 1) return "<1m";
-  if (mins < 60) return `${mins}m`;
+  if (mins < 1) return "< 1 分鐘";
+  if (mins < 60) return `${mins} 分鐘`;
 
   const hours = Math.floor(mins / 60);
   const remainingMins = mins % 60;
-  return `${hours}h ${remainingMins}m`;
+  return `${hours} 小時 ${remainingMins} 分鐘`;
 }
 
 const scriptPath = fileURLToPath(import.meta.url);

--- a/src/render/lines/project.ts
+++ b/src/render/lines/project.ts
@@ -93,7 +93,7 @@ export function renderProjectLine(ctx: RenderContext): string | null {
   }
 
   if (display?.showDuration !== false && ctx.sessionDuration) {
-    parts.push(label(`⏱️  ${ctx.sessionDuration}`, colors));
+    parts.push(label(`⏱️ 執行時間：${ctx.sessionDuration}`, colors));
   }
 
   const costEstimate = renderCostEstimate(ctx);

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -216,7 +216,7 @@ export function renderSessionLine(ctx: RenderContext): string {
   }
 
   if (display?.showDuration !== false && ctx.sessionDuration) {
-    parts.push(label(`⏱️  ${ctx.sessionDuration}`, colors));
+    parts.push(label(`⏱️ 執行時間：${ctx.sessionDuration}`, colors));
   }
 
   const costEstimate = renderCostEstimate(ctx);

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -17,11 +17,11 @@ test("formatSessionDuration formats sub-minute and minute durations", () => {
   const start = new Date(0);
   assert.equal(
     formatSessionDuration(start, () => 30 * 1000),
-    "<1m",
+    "< 1 分鐘",
   );
   assert.equal(
     formatSessionDuration(start, () => 5 * 60 * 1000),
-    "5m",
+    "5 分鐘",
   );
 });
 
@@ -29,7 +29,7 @@ test("formatSessionDuration formats hour durations", () => {
   const start = new Date(0);
   assert.equal(
     formatSessionDuration(start, () => 2 * 60 * 60 * 1000 + 5 * 60 * 1000),
-    "2h 5m",
+    "2 小時 5 分鐘",
   );
 });
 
@@ -38,7 +38,7 @@ test("formatSessionDuration uses Date.now by default", () => {
   Date.now = () => 60000;
   try {
     const result = formatSessionDuration(new Date(0));
-    assert.equal(result, "1m");
+    assert.equal(result, "1 分鐘");
   } finally {
     Date.now = originalNow;
   }
@@ -160,7 +160,7 @@ test("main executes the happy path with default dependencies", async () => {
     Date.now = originalNow;
   }
 
-  assert.equal(renderedContext?.sessionDuration, "1m");
+  assert.equal(renderedContext?.sessionDuration, "1 分鐘");
   assert.equal(renderedContext?.outputStyle, "tech-leader");
 });
 

--- a/tests/render-width.test.js
+++ b/tests/render-width.test.js
@@ -223,18 +223,18 @@ test('render ignores OSC 8 hyperlink sequences when measuring line width', () =>
   ctx.config.display.showConfigCounts = false;
   ctx.config.display.showUsage = false;
   ctx.stdin.cwd = '/tmp/my-project';
-  ctx.sessionDuration = '1m';
+  ctx.sessionDuration = '1 分鐘';
   ctx.extraLabel = '\x1b]8;;file:///tmp/my-project\x1b\\linked-label\x1b]8;;\x1b\\';
 
   let lines = [];
-  withTerminal(47, () => {
+  withTerminal(65, () => {
     lines = captureRender(ctx);
   });
 
   assert.equal(lines.length, 1, 'a visibly short line with an OSC 8 hyperlink should stay on one line');
   assert.ok(lines[0].includes('linked-label'), 'hyperlink label text should still render');
-  assert.ok(lines[0].includes('1m'), 'later elements should not be wrapped off the line');
-  assert.ok(displayWidth(lines[0]) <= 47, 'visible width should respect terminal width');
+  assert.ok(lines[0].includes('1 分鐘'), 'later elements should not be wrapped off the line');
+  assert.ok(displayWidth(lines[0]) <= 65, 'visible width should respect terminal width');
 });
 
 test('render ignores BEL-terminated OSC 8 hyperlink sequences when measuring line width', () => {
@@ -245,18 +245,18 @@ test('render ignores BEL-terminated OSC 8 hyperlink sequences when measuring lin
   ctx.config.display.showConfigCounts = false;
   ctx.config.display.showUsage = false;
   ctx.stdin.cwd = '/tmp/my-project';
-  ctx.sessionDuration = '1m';
+  ctx.sessionDuration = '1 分鐘';
   ctx.extraLabel = '\x1b]8;;file:///tmp/my-project\x07linked-label\x1b]8;;\x07';
 
   let lines = [];
-  withTerminal(47, () => {
+  withTerminal(65, () => {
     lines = captureRender(ctx);
   });
 
   assert.equal(lines.length, 1, 'a visibly short BEL-terminated OSC 8 hyperlink should stay on one line');
   assert.ok(lines[0].includes('linked-label'), 'hyperlink label text should still render');
-  assert.ok(lines[0].includes('1m'), 'later elements should not be wrapped off the line');
-  assert.ok(displayWidth(lines[0]) <= 47, 'visible width should respect terminal width');
+  assert.ok(lines[0].includes('1 分鐘'), 'later elements should not be wrapped off the line');
+  assert.ok(displayWidth(lines[0]) <= 65, 'visible width should respect terminal width');
 });
 
 test('render falls back to a safe default width when no terminal size is available', () => {

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -692,7 +692,7 @@ test('render expanded layout includes speed and duration on the project line', a
 
     assert.ok(projectLine, 'expected an expanded project line');
     assert.ok(projectLine.includes('out: 1000.0 tok/s'), 'should include deterministic speed');
-    assert.ok(projectLine.includes('⏱️  12m 34s'), 'should include session duration');
+    assert.ok(projectLine.includes('⏱️ 執行時間：12m 34s'), 'should include session duration');
   });
 });
 


### PR DESCRIPTION
## What was changed

Localize the session duration display:

- **Label**: Changed from `⏱️  {duration}` to `⏱️ 執行時間：{duration}` (one space between emoji and text)
- **Format**: Replaced English duration units with Chinese:
  - Under 1 minute: `< 1 分鐘`
  - Minutes only: `{n} 分鐘`
  - Hours and minutes: `{h} 小時 {m} 分鐘`

## Files modified

- `src/index.ts` — `formatSessionDuration()` output format
- `src/render/session-line.ts` — duration label in compact mode
- `src/render/lines/project.ts` — duration label in expanded mode
- `tests/index.test.js` — updated duration format assertions
- `tests/render.test.js` — updated duration label assertion
- `tests/render-width.test.js` — updated OSC8 width tests for wider label

## Build result

✅ `npx tsc` — no errors
✅ `npm run test:coverage` — all non-environment tests pass