### PR TITLE
override 4: add weekly usage as a separate HUD element

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -17,7 +17,7 @@ export type ContextValueMode = 'percent' | 'tokens' | 'remaining' | 'both';
  *   short:   Strip context suffix AND "Claude " prefix (e.g. "Opus 4.6")
  */
 export type ModelFormatMode = 'full' | 'compact' | 'short';
-export type HudElement = 'project' | 'context' | 'usage' | 'memory' | 'environment' | 'tools' | 'agents' | 'todos';
+export type HudElement = 'project' | 'context' | 'usage' | 'weeklyUsage' | 'memory' | 'environment' | 'tools' | 'agents' | 'todos';
 export type HudColorName =
   | 'dim'
   | 'red'
@@ -47,8 +47,9 @@ export interface HudColorOverrides {
 
 export const DEFAULT_ELEMENT_ORDER: HudElement[] = [
   'project',
-  'context',
   'usage',
+  'weeklyUsage',
+  'context',
   'memory',
   'environment',
   'tools',

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -11,6 +11,7 @@ import {
   renderGitFilesLine,
   renderEnvironmentLine,
   renderUsageLine,
+  renderWeeklyUsageLine,
   renderMemoryLine,
   renderSessionTokensLine,
 } from './lines/index.js';
@@ -349,6 +350,8 @@ function renderElementLine(ctx: RenderContext, element: HudElement): string | nu
       return renderIdentityLine(ctx);
     case 'usage':
       return renderUsageLine(ctx);
+    case 'weeklyUsage':
+      return renderWeeklyUsageLine(ctx);
     case 'memory':
       return renderMemoryLine(ctx);
     case 'environment':

--- a/src/render/lines/index.ts
+++ b/src/render/lines/index.ts
@@ -2,5 +2,6 @@ export { renderIdentityLine } from './identity.js';
 export { renderProjectLine, renderGitFilesLine } from './project.js';
 export { renderEnvironmentLine } from './environment.js';
 export { renderUsageLine } from './usage.js';
+export { renderWeeklyUsageLine } from './weekly-usage.js';
 export { renderMemoryLine } from './memory.js';
 export { renderSessionTokensLine } from './session-tokens.js';

--- a/src/render/lines/usage.ts
+++ b/src/render/lines/usage.ts
@@ -33,29 +33,13 @@ export function renderUsageLine(ctx: RenderContext): string | null {
 
   const threshold = display?.usageThreshold ?? 0;
   const fiveHour = ctx.usageData.fiveHour;
-  const sevenDay = ctx.usageData.sevenDay;
 
-  const effectiveUsage = Math.max(fiveHour ?? 0, sevenDay ?? 0);
-  if (effectiveUsage < threshold) {
+  if ((fiveHour ?? 0) < threshold) {
     return null;
   }
 
   const usageBarEnabled = display?.usageBarEnabled ?? true;
-  const sevenDayThreshold = display?.sevenDayThreshold ?? 80;
   const barWidth = getAdaptiveBarWidth();
-
-  if (fiveHour === null && sevenDay !== null) {
-    const weeklyOnlyPart = formatUsageWindowPart({
-      label: t("label.weekly"),
-      percent: sevenDay,
-      resetAt: ctx.usageData.sevenDayResetAt,
-      colors,
-      usageBarEnabled,
-      barWidth,
-      forceLabel: true,
-    });
-    return `${usageLabel} ${weeklyOnlyPart}`;
-  }
 
   const fiveHourPart = formatUsageWindowPart({
     label: "5h",
@@ -65,19 +49,6 @@ export function renderUsageLine(ctx: RenderContext): string | null {
     usageBarEnabled,
     barWidth,
   });
-
-  if (sevenDay !== null && sevenDay >= sevenDayThreshold) {
-    const sevenDayPart = formatUsageWindowPart({
-      label: t("label.weekly"),
-      percent: sevenDay,
-      resetAt: ctx.usageData.sevenDayResetAt,
-      colors,
-      usageBarEnabled,
-      barWidth,
-      forceLabel: true,
-    });
-    return `${usageLabel} ${fiveHourPart} | ${sevenDayPart}`;
-  }
 
   return `${usageLabel} ${fiveHourPart}`;
 }

--- a/src/render/lines/weekly-usage.ts
+++ b/src/render/lines/weekly-usage.ts
@@ -1,0 +1,78 @@
+import type { RenderContext } from "../../types.js";
+import { getProviderLabel } from "../../stdin.js";
+import { label, getQuotaColor, quotaBar, RESET } from "../colors.js";
+import { getAdaptiveBarWidth } from "../../utils/terminal.js";
+import { t } from "../../i18n/index.js";
+
+export function renderWeeklyUsageLine(ctx: RenderContext): string | null {
+  const display = ctx.config?.display;
+  const colors = ctx.config?.colors;
+
+  if (display?.showUsage === false) {
+    return null;
+  }
+
+  if (!ctx.usageData) {
+    return null;
+  }
+
+  if (getProviderLabel(ctx.stdin)) {
+    return null;
+  }
+
+  const sevenDay = ctx.usageData.sevenDay;
+  if (sevenDay === null) {
+    return null;
+  }
+
+  const weeklyLabel = label(t("label.weekly"), colors);
+  const barWidth = getAdaptiveBarWidth();
+  const usageBarEnabled = display?.usageBarEnabled ?? true;
+
+  const usageDisplay = formatUsagePercent(sevenDay, colors);
+  const reset = formatResetTime(ctx.usageData.sevenDayResetAt);
+
+  if (usageBarEnabled) {
+    const body = reset
+      ? `${quotaBar(sevenDay, barWidth, colors)} ${usageDisplay} (${t("format.resetsIn")} ${reset})`
+      : `${quotaBar(sevenDay, barWidth, colors)} ${usageDisplay}`;
+    return `${weeklyLabel} ${body}`;
+  }
+
+  return reset
+    ? `${weeklyLabel} ${usageDisplay} (${t("format.resetsIn")} ${reset})`
+    : `${weeklyLabel} ${usageDisplay}`;
+}
+
+function formatUsagePercent(
+  percent: number | null,
+  colors?: RenderContext["config"]["colors"],
+): string {
+  if (percent === null) {
+    return label("--", colors);
+  }
+  const color = getQuotaColor(percent, colors);
+  return `${color}${percent}%${RESET}`;
+}
+
+function formatResetTime(resetAt: Date | null): string {
+  if (!resetAt) return "";
+  const now = new Date();
+  const diffMs = resetAt.getTime() - now.getTime();
+  if (diffMs <= 0) return "";
+
+  const diffMins = Math.ceil(diffMs / 60000);
+  if (diffMins < 60) return `${diffMins}m`;
+
+  const hours = Math.floor(diffMins / 60);
+  const mins = diffMins % 60;
+
+  if (hours >= 24) {
+    const days = Math.floor(hours / 24);
+    const remHours = hours % 24;
+    if (remHours > 0) return `${days}d ${remHours}h`;
+    return `${days}d`;
+  }
+
+  return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`;
+}

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -10,6 +10,7 @@ import { renderToolsLine } from '../dist/render/tools-line.js';
 import { renderAgentsLine } from '../dist/render/agents-line.js';
 import { renderTodosLine } from '../dist/render/todos-line.js';
 import { renderUsageLine } from '../dist/render/lines/usage.js';
+import { renderWeeklyUsageLine } from '../dist/render/lines/weekly-usage.js';
 import { renderMemoryLine } from '../dist/render/lines/memory.js';
 import { renderIdentityLine } from '../dist/render/lines/identity.js';
 import { renderEnvironmentLine } from '../dist/render/lines/environment.js';
@@ -48,7 +49,7 @@ function baseContext() {
       lineLayout: 'compact',
       showSeparators: false,
       pathLevels: 1,
-      elementOrder: ['project', 'context', 'usage', 'memory', 'environment', 'tools', 'agents', 'todos'],
+      elementOrder: ['project', 'usage', 'weeklyUsage', 'context', 'memory', 'environment', 'tools', 'agents', 'todos'],
       gitStatus: { enabled: true, showDirty: true, showAheadBehind: false, showFileStats: false, pushWarningThreshold: 0, pushCriticalThreshold: 0 },
       display: { showModel: true, showProject: true, showContextBar: true, contextValue: 'percent', showConfigCounts: true, showCost: false, showDuration: true, showSpeed: false, showTokenBreakdown: true, showUsage: true, usageBarEnabled: false, showTools: true, showAgents: true, showTodos: true, showSessionTokens: false, showSessionName: false, showClaudeCodeVersion: false, showMemoryUsage: false, showOutputStyle: false, autocompactBuffer: 'enabled', usageThreshold: 0, sevenDayThreshold: 80, environmentThreshold: 0, customLine: '' },
       colors: {
@@ -1215,11 +1216,10 @@ test('renderUsageLine shows reset countdown in days when >= 24 hours', () => {
   assert.ok(!plain.includes('151h'), `should avoid raw hour format for long durations: ${plain}`);
 });
 
-test('renderUsageLine shows 7d reset countdown in text-only mode', () => {
+test('renderWeeklyUsageLine shows 7d reset countdown in text-only mode', () => {
   const ctx = baseContext();
   const resetTime = new Date(Date.now() + (28 * 60 * 60 * 1000)); // 1d 4h from now
   ctx.config.display.usageBarEnabled = false;
-  ctx.config.display.sevenDayThreshold = 80;
   ctx.usageData = {
     planName: 'Pro',
     fiveHour: 45,
@@ -1228,15 +1228,13 @@ test('renderUsageLine shows 7d reset countdown in text-only mode', () => {
     sevenDayResetAt: resetTime,
   };
 
-  const line = stripAnsi(renderUsageLine(ctx));
-  assert.ok(line.includes('5h 45%'), `should include 5h text-only usage: ${line}`);
+  const line = stripAnsi(renderWeeklyUsageLine(ctx));
   assert.ok(line.includes('Weekly 85%'), `should include 7d text-only usage: ${line}`);
   assert.ok(line.includes('(resets in 1d 4h)'), `should include 7d reset countdown in text-only mode: ${line}`);
 });
 
-test('renderUsageLine translates weekly label when Chinese is enabled', () => {
+test('renderWeeklyUsageLine translates weekly label when Chinese is enabled', () => {
   const ctx = baseContext();
-  ctx.config.display.sevenDayThreshold = 80;
   ctx.usageData = {
     planName: 'Pro',
     fiveHour: 45,
@@ -1247,7 +1245,7 @@ test('renderUsageLine translates weekly label when Chinese is enabled', () => {
 
   setLanguage('zh');
   try {
-    const line = stripAnsi(renderUsageLine(ctx) ?? '');
+    const line = stripAnsi(renderWeeklyUsageLine(ctx) ?? '');
     assert.ok(line.includes('本周'));
     assert.ok(line.includes('重置剩余'));
   } finally {
@@ -1255,11 +1253,10 @@ test('renderUsageLine translates weekly label when Chinese is enabled', () => {
   }
 });
 
-test('renderUsageLine shows 7d reset countdown in bar mode when above threshold', () => {
+test('renderWeeklyUsageLine shows 7d reset countdown in bar mode', () => {
   const ctx = baseContext();
   const resetTime = new Date(Date.now() + (28 * 60 * 60 * 1000)); // 1d 4h from now
   ctx.config.display.usageBarEnabled = true;
-  ctx.config.display.sevenDayThreshold = 80;
   ctx.usageData = {
     planName: 'Pro',
     fiveHour: 45,
@@ -1268,16 +1265,13 @@ test('renderUsageLine shows 7d reset countdown in bar mode when above threshold'
     sevenDayResetAt: resetTime,
   };
 
-  const line = stripAnsi(renderUsageLine(ctx));
-  assert.ok(line.includes('45%'), `should include 5h percentage in bar mode: ${line}`);
+  const line = stripAnsi(renderWeeklyUsageLine(ctx));
   assert.ok(line.includes('85%'), `should include 7d percentage: ${line}`);
   assert.ok(line.includes('(resets in 1d 4h)'), `should include 7d reset countdown in bar mode: ${line}`);
-  assert.ok(line.includes('|'), `should render both usage windows above the threshold: ${line}`);
 });
 
-test('renderUsageLine shows weekly-only usage without a ghost 5h section', () => {
+test('renderWeeklyUsageLine shows weekly usage as independent line', () => {
   const ctx = baseContext();
-  ctx.config.display.sevenDayThreshold = 80;
   ctx.usageData = {
     planName: 'Pro',
     fiveHour: null,
@@ -1286,12 +1280,9 @@ test('renderUsageLine shows weekly-only usage without a ghost 5h section', () =>
     sevenDayResetAt: null,
   };
 
-  const line = stripAnsi(renderUsageLine(ctx));
-  assert.ok(line.includes('Usage'), `should render usage line: ${line}`);
-  assert.ok(!line.includes('5h'), `should not render a ghost 5h section: ${line}`);
-  assert.ok(line.includes('Weekly'), `should render the weekly window when it is the only usage value: ${line}`);
+  const line = stripAnsi(renderWeeklyUsageLine(ctx));
+  assert.ok(line.includes('Weekly'), `should render weekly label: ${line}`);
   assert.ok(line.includes('13%'), `should render the weekly percentage: ${line}`);
-  assert.ok(!line.includes('|'), `should not render a separator for a missing 5h window: ${line}`);
 });
 
 test('renderSessionLine displays limit reached warning', () => {
@@ -1392,8 +1383,12 @@ test('renderUsageLine uses custom usage palette overrides', () => {
   assert.ok(line, 'should render usage line');
   assert.ok(line.includes('\x1b[36m███'), `expected custom usage bar color, got: ${JSON.stringify(line)}`);
   assert.ok(line.includes('\x1b[36m25%\x1b[0m'), `expected custom usage percentage color, got: ${JSON.stringify(line)}`);
-  assert.ok(line.includes('\x1b[35m████████'), `expected custom usage warning color, got: ${JSON.stringify(line)}`);
-  assert.ok(line.includes('\x1b[35m80%\x1b[0m'), `expected custom usage warning percentage color, got: ${JSON.stringify(line)}`);
+
+  // Weekly usage is now a separate element; test it via renderWeeklyUsageLine
+  const weeklyLine = withTerminal(120, () => renderWeeklyUsageLine(ctx));
+  assert.ok(weeklyLine, 'should render weekly usage line');
+  assert.ok(weeklyLine.includes('\x1b[35m████████'), `expected custom usage warning color, got: ${JSON.stringify(weeklyLine)}`);
+  assert.ok(weeklyLine.includes('\x1b[35m80%\x1b[0m'), `expected custom usage warning percentage color, got: ${JSON.stringify(weeklyLine)}`);
 });
 
 test('renderSessionLine hides usage when showUsage config is false (hybrid toggle)', () => {


### PR DESCRIPTION
## What was changed

Split weekly usage out of the combined usage element into its own independent `weeklyUsage` HUD element that is always visible as a separate line, regardless of threshold.

- Added `weeklyUsage` to the `HudElement` type definition
- Created `renderWeeklyUsageLine()` in new `src/render/lines/weekly-usage.ts`
- Removed weekly usage rendering from `usage.ts` (now five-hour only)
- Registered `weeklyUsage` in render coordinator's element-to-renderer mapping
- Updated default element order to `[project, usage, weeklyUsage, context, ...]`, placing `weeklyUsage` after `usage` and before `context`, which naturally breaks the context+usage same-line combining logic

## Files modified

- `src/config.ts` — HudElement type, DEFAULT_ELEMENT_ORDER
- `src/render/lines/weekly-usage.ts` — new render function
- `src/render/lines/usage.ts` — removed weekly rendering
- `src/render/lines/index.ts` — barrel export
- `src/render/index.ts` — import + switch case
- `tests/render.test.js` — migrated weekly tests to renderWeeklyUsageLine

## Build result

✅ `npx tsc` — no errors
✅ `npm run test:coverage` — all non-environment tests pass