### PR TITLE
override 5: change bar characters from blocks to dots

### DIFF
--- a/src/render/colors.ts
+++ b/src/render/colors.ts
@@ -134,7 +134,7 @@ export function quotaBar(percent: number, width: number = 10, colors?: Partial<H
   const filled = Math.round((safePercent / 100) * safeWidth);
   const empty = safeWidth - filled;
   const color = getQuotaColor(safePercent, colors);
-  return `${color}${'█'.repeat(filled)}${DIM}${'░'.repeat(empty)}${RESET}`;
+  return `${color}${'●'.repeat(filled)}${DIM}${'○'.repeat(empty)}${RESET}`;
 }
 
 export function coloredBar(percent: number, width: number = 10, colors?: Partial<HudColorOverrides>): string {
@@ -143,5 +143,5 @@ export function coloredBar(percent: number, width: number = 10, colors?: Partial
   const filled = Math.round((safePercent / 100) * safeWidth);
   const empty = safeWidth - filled;
   const color = getContextColor(safePercent, colors);
-  return `${color}${'█'.repeat(filled)}${DIM}${'░'.repeat(empty)}${RESET}`;
+  return `${color}${'●'.repeat(filled)}${DIM}${'○'.repeat(empty)}${RESET}`;
 }

--- a/tests/fixtures/expected/render-basic.txt
+++ b/tests/fixtures/expected/render-basic.txt
@@ -1,2 +1,2 @@
 [Opus] │ my-project
-Context ███░░░░░░░ 29%
+Context ●●●○○○○○○○ 29%

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -1390,9 +1390,9 @@ test('renderUsageLine uses custom usage palette overrides', () => {
 
   const line = withTerminal(120, () => renderUsageLine(ctx));
   assert.ok(line, 'should render usage line');
-  assert.ok(line.includes('\x1b[36m███'), `expected custom usage bar color, got: ${JSON.stringify(line)}`);
+  assert.ok(line.includes('\x1b[36m●●●'), `expected custom usage bar color, got: ${JSON.stringify(line)}`);
   assert.ok(line.includes('\x1b[36m25%\x1b[0m'), `expected custom usage percentage color, got: ${JSON.stringify(line)}`);
-  assert.ok(line.includes('\x1b[35m████████'), `expected custom usage warning color, got: ${JSON.stringify(line)}`);
+  assert.ok(line.includes('\x1b[35m●●●●●●●●'), `expected custom usage warning color, got: ${JSON.stringify(line)}`);
   assert.ok(line.includes('\x1b[35m80%\x1b[0m'), `expected custom usage warning percentage color, got: ${JSON.stringify(line)}`);
 });
 


### PR DESCRIPTION
## What was changed

Replace the filled bar character `█` with `●` and the empty bar character `░` with `○` in both `quotaBar()` and `coloredBar()` functions. The original color scheme is preserved — only the characters changed.

## Files modified

- `src/render/colors.ts` — bar character constants in `quotaBar()` and `coloredBar()`
- `tests/render.test.js` — updated bar character assertions
- `tests/fixtures/expected/render-basic.txt` — updated expected output fixture

## Build result

✅ `npx tsc` — no errors
✅ `npm run test:coverage` — all non-environment tests pass