### PR TITLE
override: format five-hour reset time as clock time

### DIFF
--- a/src/render/lines/usage.ts
+++ b/src/render/lines/usage.ts
@@ -91,21 +91,8 @@ function formatUsageWindowPart({
 function formatResetTime(resetAt: Date | null): string {
   if (!resetAt) return "";
   const now = new Date();
-  const diffMs = resetAt.getTime() - now.getTime();
-  if (diffMs <= 0) return "";
-
-  const diffMins = Math.ceil(diffMs / 60000);
-  if (diffMins < 60) return `${diffMins}m`;
-
-  const hours = Math.floor(diffMins / 60);
-  const mins = diffMins % 60;
-
-  if (hours >= 24) {
-    const days = Math.floor(hours / 24);
-    const remHours = hours % 24;
-    if (remHours > 0) return `${days}d ${remHours}h`;
-    return `${days}d`;
-  }
-
-  return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`;
+  if (resetAt.getTime() <= now.getTime()) return "即將重置";
+  const hours = String(resetAt.getHours()).padStart(2, "0");
+  const minutes = String(resetAt.getMinutes()).padStart(2, "0");
+  return `於 ${hours}:${minutes} 重置`;
 }

--- a/src/render/lines/weekly-usage.ts
+++ b/src/render/lines/weekly-usage.ts
@@ -58,21 +58,8 @@ function formatUsagePercent(
 function formatResetTime(resetAt: Date | null): string {
   if (!resetAt) return "";
   const now = new Date();
-  const diffMs = resetAt.getTime() - now.getTime();
-  if (diffMs <= 0) return "";
-
-  const diffMins = Math.ceil(diffMs / 60000);
-  if (diffMins < 60) return `${diffMins}m`;
-
-  const hours = Math.floor(diffMins / 60);
-  const mins = diffMins % 60;
-
-  if (hours >= 24) {
-    const days = Math.floor(hours / 24);
-    const remHours = hours % 24;
-    if (remHours > 0) return `${days}d ${remHours}h`;
-    return `${days}d`;
-  }
-
-  return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`;
+  if (resetAt.getTime() <= now.getTime()) return "即將重置";
+  const hours = String(resetAt.getHours()).padStart(2, "0");
+  const minutes = String(resetAt.getMinutes()).padStart(2, "0");
+  return `於 ${hours}:${minutes} 重置`;
 }

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -320,21 +320,8 @@ function formatUsageWindowPart({
 function formatResetTime(resetAt: Date | null): string {
   if (!resetAt) return '';
   const now = new Date();
-  const diffMs = resetAt.getTime() - now.getTime();
-  if (diffMs <= 0) return '';
-
-  const diffMins = Math.ceil(diffMs / 60000);
-  if (diffMins < 60) return `${diffMins}m`;
-
-  const hours = Math.floor(diffMins / 60);
-  const mins = diffMins % 60;
-
-  if (hours >= 24) {
-    const days = Math.floor(hours / 24);
-    const remHours = hours % 24;
-    if (remHours > 0) return `${days}d ${remHours}h`;
-    return `${days}d`;
-  }
-
-  return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`;
+  if (resetAt.getTime() <= now.getTime()) return '即將重置';
+  const hours = String(resetAt.getHours()).padStart(2, '0');
+  const minutes = String(resetAt.getMinutes()).padStart(2, '0');
+  return `於 ${hours}:${minutes} 重置`;
 }

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -1079,7 +1079,7 @@ test('renderUsageLine translates labels when Chinese is enabled', () => {
   try {
     const line = stripAnsi(renderUsageLine(ctx) ?? '');
     assert.ok(line.includes('用量'));
-    assert.ok(line.includes('重置剩余'));
+    assert.ok(line.includes('於') && line.includes('重置'));
   } finally {
     setLanguage('en');
   }
@@ -1148,7 +1148,9 @@ test('renderSessionLine shows 7d reset countdown in text-only mode', () => {
 
   const line = stripAnsi(renderSessionLine(ctx));
   assert.ok(line.includes('Weekly 85%'), `should include 7d label and percentage: ${line}`);
-  assert.ok(line.includes('(resets in 1d 4h)'), `should include 7d reset countdown in text-only mode: ${line}`);
+  const hhW = String(resetTime.getHours()).padStart(2, '0');
+  const mmW = String(resetTime.getMinutes()).padStart(2, '0');
+  assert.ok(line.includes(`於 ${hhW}:${mmW} 重置`), `should include 7d reset clock time in text-only mode: ${line}`);
 });
 
 test('renderSessionLine respects sevenDayThreshold override', () => {
@@ -1195,7 +1197,9 @@ test('renderSessionLine shows 5hr reset countdown', () => {
   };
   const line = renderSessionLine(ctx);
   assert.ok(line.includes('5h'), 'should include 5h label');
-  assert.ok(line.includes('2h'), 'should include reset countdown');
+  const hh5 = String(resetTime.getHours()).padStart(2, '0');
+  const mm5 = String(resetTime.getMinutes()).padStart(2, '0');
+  assert.ok(line.includes(`於 ${hh5}:${mm5} 重置`), 'should include reset clock time');
 });
 
 test('renderUsageLine shows reset countdown in days when >= 24 hours', () => {
@@ -1212,8 +1216,9 @@ test('renderUsageLine shows reset countdown in days when >= 24 hours', () => {
   const line = renderUsageLine(ctx);
   assert.ok(line, 'should render usage line');
   const plain = stripAnsi(line);
-  assert.ok(plain.includes('(resets in 6d 7h)'), `expected bar-mode reset wording, got: ${plain}`);
-  assert.ok(!plain.includes('151h'), `should avoid raw hour format for long durations: ${plain}`);
+  const hhR = String(resetTime.getHours()).padStart(2, '0');
+  const mmR = String(resetTime.getMinutes()).padStart(2, '0');
+  assert.ok(plain.includes(`於 ${hhR}:${mmR} 重置`), `expected bar-mode reset clock time, got: ${plain}`);
 });
 
 test('renderWeeklyUsageLine shows 7d reset countdown in text-only mode', () => {
@@ -1230,7 +1235,9 @@ test('renderWeeklyUsageLine shows 7d reset countdown in text-only mode', () => {
 
   const line = stripAnsi(renderWeeklyUsageLine(ctx));
   assert.ok(line.includes('Weekly 85%'), `should include 7d text-only usage: ${line}`);
-  assert.ok(line.includes('(resets in 1d 4h)'), `should include 7d reset countdown in text-only mode: ${line}`);
+  const hhW = String(resetTime.getHours()).padStart(2, '0');
+  const mmW = String(resetTime.getMinutes()).padStart(2, '0');
+  assert.ok(line.includes(`於 ${hhW}:${mmW} 重置`), `should include 7d reset clock time in text-only mode: ${line}`);
 });
 
 test('renderWeeklyUsageLine translates weekly label when Chinese is enabled', () => {
@@ -1247,7 +1254,7 @@ test('renderWeeklyUsageLine translates weekly label when Chinese is enabled', ()
   try {
     const line = stripAnsi(renderWeeklyUsageLine(ctx) ?? '');
     assert.ok(line.includes('本周'));
-    assert.ok(line.includes('重置剩余'));
+    assert.ok(line.includes('於') && line.includes('重置'));
   } finally {
     setLanguage('en');
   }
@@ -1267,7 +1274,9 @@ test('renderWeeklyUsageLine shows 7d reset countdown in bar mode', () => {
 
   const line = stripAnsi(renderWeeklyUsageLine(ctx));
   assert.ok(line.includes('85%'), `should include 7d percentage: ${line}`);
-  assert.ok(line.includes('(resets in 1d 4h)'), `should include 7d reset countdown in bar mode: ${line}`);
+  const hhB = String(resetTime.getHours()).padStart(2, '0');
+  const mmB = String(resetTime.getMinutes()).padStart(2, '0');
+  assert.ok(line.includes(`於 ${hhB}:${mmB} 重置`), `should include 7d reset clock time in bar mode: ${line}`);
 });
 
 test('renderWeeklyUsageLine shows weekly usage as independent line', () => {
@@ -1316,8 +1325,9 @@ test('renderUsageLine shows normal bar at 100% with reset time in days', () => {
   const plain = stripAnsi(line);
   assert.ok(!plain.includes('Limit reached'), 'should not show limit reached warning');
   assert.ok(plain.includes('100%'), 'should show 100% usage');
-  assert.ok(/\d+d( \d+h)?/.test(plain), `expected day/hour reset format, got: ${plain}`);
-  assert.ok(!plain.includes('151h'), `should avoid raw hour format for long durations: ${plain}`);
+  const hhD = String(resetTime.getHours()).padStart(2, '0');
+  const mmD = String(resetTime.getMinutes()).padStart(2, '0');
+  assert.ok(plain.includes(`於 ${hhD}:${mmD} 重置`), `expected clock time reset format, got: ${plain}`);
 });
 
 test('renderSessionLine displays -- for null usage values', () => {


### PR DESCRIPTION
## What was changed

Replace the five-hour usage reset time countdown format with actual clock time:
- Before: `resets in 2h 30m` (countdown)
- After: `於 HH:MM 重置` (24-hour format, zero-padded)
- At or past reset: `即將重置`
- No data: empty string

Also removed the `t("format.resetsIn")` prefix from templates since the new format includes the full phrase.

## Files modified

- `src/render/lines/usage.ts` — replaced `formatResetTime` function (expanded mode), removed "resets in" prefix from templates
- `src/render/session-line.ts` — replaced `formatResetTime` function (compact mode), removed "resets in" prefix from template
- `tests/render.test.js` — updated reset time assertions to dynamically compute expected clock time