### PR TITLE
override: format weekly reset time with date

### DIFF
--- a/src/render/lines/weekly-usage.ts
+++ b/src/render/lines/weekly-usage.ts
@@ -30,17 +30,17 @@ export function renderWeeklyUsageLine(ctx: RenderContext): string | null {
   const usageBarEnabled = display?.usageBarEnabled ?? true;
 
   const usageDisplay = formatUsagePercent(sevenDay, colors);
-  const reset = formatResetTime(ctx.usageData.sevenDayResetAt);
+  const reset = formatWeeklyResetTime(ctx.usageData.sevenDayResetAt);
 
   if (usageBarEnabled) {
     const body = reset
-      ? `${quotaBar(sevenDay, barWidth, colors)} ${usageDisplay} (${t("format.resetsIn")} ${reset})`
+      ? `${quotaBar(sevenDay, barWidth, colors)} ${usageDisplay} (${reset})`
       : `${quotaBar(sevenDay, barWidth, colors)} ${usageDisplay}`;
     return `${weeklyLabel} ${body}`;
   }
 
   return reset
-    ? `${weeklyLabel} ${usageDisplay} (${t("format.resetsIn")} ${reset})`
+    ? `${weeklyLabel} ${usageDisplay} (${reset})`
     : `${weeklyLabel} ${usageDisplay}`;
 }
 
@@ -55,24 +55,10 @@ function formatUsagePercent(
   return `${color}${percent}%${RESET}`;
 }
 
-function formatResetTime(resetAt: Date | null): string {
+function formatWeeklyResetTime(resetAt: Date | null): string {
   if (!resetAt) return "";
-  const now = new Date();
-  const diffMs = resetAt.getTime() - now.getTime();
-  if (diffMs <= 0) return "";
-
-  const diffMins = Math.ceil(diffMs / 60000);
-  if (diffMins < 60) return `${diffMins}m`;
-
-  const hours = Math.floor(diffMins / 60);
-  const mins = diffMins % 60;
-
-  if (hours >= 24) {
-    const days = Math.floor(hours / 24);
-    const remHours = hours % 24;
-    if (remHours > 0) return `${days}d ${remHours}h`;
-    return `${days}d`;
-  }
-
-  return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`;
+  const month = resetAt.getMonth() + 1;
+  const day = resetAt.getDate();
+  const hh = String(resetAt.getHours()).padStart(2, "0");
+  return `${month} 月 ${day} 號 ${hh}:00 重置`;
 }

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -164,6 +164,7 @@ export function renderSessionLine(ctx: RenderContext): string {
           usageBarEnabled,
           barWidth,
           forceLabel: true,
+          resetFormatter: formatWeeklyResetTime,
         });
         parts.push(weeklyOnlyPart);
       } else {
@@ -186,6 +187,7 @@ export function renderSessionLine(ctx: RenderContext): string {
             usageBarEnabled,
             barWidth,
             forceLabel: true,
+            resetFormatter: formatWeeklyResetTime,
           });
           parts.push(`${label(t('label.usage'), colors)} ${fiveHourPart}`);
           parts.push(sevenDayPart);
@@ -292,6 +294,7 @@ function formatUsageWindowPart({
   usageBarEnabled,
   barWidth,
   forceLabel = false,
+  resetFormatter,
 }: {
   label: string;
   percent: number | null;
@@ -300,9 +303,10 @@ function formatUsageWindowPart({
   usageBarEnabled: boolean;
   barWidth: number;
   forceLabel?: boolean;
+  resetFormatter?: (resetAt: Date | null) => string;
 }): string {
   const usageDisplay = formatUsagePercent(percent, colors);
-  const reset = formatResetTime(resetAt);
+  const reset = (resetFormatter ?? formatResetTime)(resetAt);
   const styledLabel = label(windowLabel, colors);
 
   if (usageBarEnabled) {
@@ -312,6 +316,11 @@ function formatUsageWindowPart({
     return forceLabel ? `${styledLabel} ${body}` : body;
   }
 
+  if (resetFormatter) {
+    return reset
+      ? `${styledLabel} ${usageDisplay} (${reset})`
+      : `${styledLabel} ${usageDisplay}`;
+  }
   return reset
     ? `${styledLabel} ${usageDisplay} (${t('format.resetsIn')} ${reset})`
     : `${styledLabel} ${usageDisplay}`;
@@ -337,4 +346,12 @@ function formatResetTime(resetAt: Date | null): string {
   }
 
   return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`;
+}
+
+function formatWeeklyResetTime(resetAt: Date | null): string {
+  if (!resetAt) return '';
+  const month = resetAt.getMonth() + 1;
+  const day = resetAt.getDate();
+  const hh = String(resetAt.getHours()).padStart(2, '0');
+  return `${month} 月 ${day} 號 ${hh}:00 重置`;
 }

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -1079,7 +1079,11 @@ test('renderUsageLine translates labels when Chinese is enabled', () => {
   try {
     const line = stripAnsi(renderUsageLine(ctx) ?? '');
     assert.ok(line.includes('用量'));
-    assert.ok(line.includes('重置剩余'));
+    const resetTime_ch = ctx.usageData.sevenDayResetAt;
+    const m_ch = resetTime_ch.getMonth() + 1;
+    const d_ch = resetTime_ch.getDate();
+    const h_ch = String(resetTime_ch.getHours()).padStart(2, '0');
+    assert.ok(line.includes(`${m_ch} 月 ${d_ch} 號 ${h_ch}:00 重置`));
   } finally {
     setLanguage('en');
   }
@@ -1133,7 +1137,7 @@ test('renderSessionLine shows 7d when approaching limit (>=80%)', () => {
   assert.ok(line.includes('85%'), 'should include 7d percentage');
 });
 
-test('renderSessionLine shows 7d reset countdown in text-only mode', () => {
+test('renderSessionLine shows 7d reset date in text-only mode', () => {
   const ctx = baseContext();
   const resetTime = new Date(Date.now() + (28 * 60 * 60 * 1000)); // 1d 4h from now
   ctx.config.display.sevenDayThreshold = 80;
@@ -1148,7 +1152,10 @@ test('renderSessionLine shows 7d reset countdown in text-only mode', () => {
 
   const line = stripAnsi(renderSessionLine(ctx));
   assert.ok(line.includes('Weekly 85%'), `should include 7d label and percentage: ${line}`);
-  assert.ok(line.includes('(resets in 1d 4h)'), `should include 7d reset countdown in text-only mode: ${line}`);
+  const month = resetTime.getMonth() + 1;
+  const day = resetTime.getDate();
+  const hh_w = String(resetTime.getHours()).padStart(2, '0');
+  assert.ok(line.includes(`${month} 月 ${day} 號 ${hh_w}:00 重置`), `should include 7d reset date in text-only mode: ${line}`);
 });
 
 test('renderSessionLine respects sevenDayThreshold override', () => {
@@ -1216,7 +1223,7 @@ test('renderUsageLine shows reset countdown in days when >= 24 hours', () => {
   assert.ok(!plain.includes('151h'), `should avoid raw hour format for long durations: ${plain}`);
 });
 
-test('renderWeeklyUsageLine shows 7d reset countdown in text-only mode', () => {
+test('renderWeeklyUsageLine shows 7d reset date in text-only mode', () => {
   const ctx = baseContext();
   const resetTime = new Date(Date.now() + (28 * 60 * 60 * 1000)); // 1d 4h from now
   ctx.config.display.usageBarEnabled = false;
@@ -1230,7 +1237,10 @@ test('renderWeeklyUsageLine shows 7d reset countdown in text-only mode', () => {
 
   const line = stripAnsi(renderWeeklyUsageLine(ctx));
   assert.ok(line.includes('Weekly 85%'), `should include 7d text-only usage: ${line}`);
-  assert.ok(line.includes('(resets in 1d 4h)'), `should include 7d reset countdown in text-only mode: ${line}`);
+  const month_wt = resetTime.getMonth() + 1;
+  const day_wt = resetTime.getDate();
+  const hh_wt = String(resetTime.getHours()).padStart(2, '0');
+  assert.ok(line.includes(`${month_wt} 月 ${day_wt} 號 ${hh_wt}:00 重置`), `should include 7d reset date in text-only mode: ${line}`);
 });
 
 test('renderWeeklyUsageLine translates weekly label when Chinese is enabled', () => {
@@ -1247,13 +1257,17 @@ test('renderWeeklyUsageLine translates weekly label when Chinese is enabled', ()
   try {
     const line = stripAnsi(renderWeeklyUsageLine(ctx) ?? '');
     assert.ok(line.includes('本周'));
-    assert.ok(line.includes('重置剩余'));
+    const resetTime_ch = ctx.usageData.sevenDayResetAt;
+    const m_ch = resetTime_ch.getMonth() + 1;
+    const d_ch = resetTime_ch.getDate();
+    const h_ch = String(resetTime_ch.getHours()).padStart(2, '0');
+    assert.ok(line.includes(`${m_ch} 月 ${d_ch} 號 ${h_ch}:00 重置`));
   } finally {
     setLanguage('en');
   }
 });
 
-test('renderWeeklyUsageLine shows 7d reset countdown in bar mode', () => {
+test('renderWeeklyUsageLine shows 7d reset date in bar mode', () => {
   const ctx = baseContext();
   const resetTime = new Date(Date.now() + (28 * 60 * 60 * 1000)); // 1d 4h from now
   ctx.config.display.usageBarEnabled = true;
@@ -1267,7 +1281,10 @@ test('renderWeeklyUsageLine shows 7d reset countdown in bar mode', () => {
 
   const line = stripAnsi(renderWeeklyUsageLine(ctx));
   assert.ok(line.includes('85%'), `should include 7d percentage: ${line}`);
-  assert.ok(line.includes('(resets in 1d 4h)'), `should include 7d reset countdown in bar mode: ${line}`);
+  const month_wb = resetTime.getMonth() + 1;
+  const day_wb = resetTime.getDate();
+  const hh_wb = String(resetTime.getHours()).padStart(2, '0');
+  assert.ok(line.includes(`${month_wb} 月 ${day_wb} 號 ${hh_wb}:00 重置`), `should include 7d reset date in bar mode: ${line}`);
 });
 
 test('renderWeeklyUsageLine shows weekly usage as independent line', () => {


### PR DESCRIPTION
## What was changed

Replace the weekly usage reset time countdown format with a date-based format:
- Before: `resets in 1d 4h`
- After: `{month} 月 {day} 號 HH:00 重置` (hour zero-padded, no minutes)
- No data: empty string

Added a separate `formatWeeklyResetTime` function and an optional `resetFormatter` parameter to `formatUsageWindowPart` so five-hour and weekly resets can use different formatters.

## Files modified

- `src/render/lines/weekly-usage.ts` — replaced `formatResetTime` with `formatWeeklyResetTime`, removed "resets in" prefix
- `src/render/session-line.ts` — added `formatWeeklyResetTime`, added `resetFormatter` parameter, updated weekly usage calls
- `tests/render.test.js` — updated weekly reset time assertions to use date format