### PR TITLE
override 9: format weekly reset time with date

### DIFF
--- a/src/render/lines/weekly-usage.ts
+++ b/src/render/lines/weekly-usage.ts
@@ -58,8 +58,9 @@ function formatUsagePercent(
 function formatResetTime(resetAt: Date | null): string {
   if (!resetAt) return "";
   const now = new Date();
-  if (resetAt.getTime() <= now.getTime()) return "即將重置";
+  if (resetAt.getTime() <= now.getTime()) return "";
+  const month = resetAt.getMonth() + 1;
+  const day = resetAt.getDate();
   const hours = String(resetAt.getHours()).padStart(2, "0");
-  const minutes = String(resetAt.getMinutes()).padStart(2, "0");
-  return `於 ${hours}:${minutes} 重置`;
+  return `${month} 月 ${day} 號 ${hours}:00 重置`;
 }

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -164,6 +164,7 @@ export function renderSessionLine(ctx: RenderContext): string {
           usageBarEnabled,
           barWidth,
           forceLabel: true,
+          resetFormatter: formatWeeklyResetTime,
         });
         parts.push(weeklyOnlyPart);
       } else {
@@ -186,6 +187,7 @@ export function renderSessionLine(ctx: RenderContext): string {
             usageBarEnabled,
             barWidth,
             forceLabel: true,
+            resetFormatter: formatWeeklyResetTime,
           });
           parts.push(`${label(t('label.usage'), colors)} ${fiveHourPart}`);
           parts.push(sevenDayPart);
@@ -292,6 +294,7 @@ function formatUsageWindowPart({
   usageBarEnabled,
   barWidth,
   forceLabel = false,
+  resetFormatter = formatResetTime,
 }: {
   label: string;
   percent: number | null;
@@ -300,9 +303,10 @@ function formatUsageWindowPart({
   usageBarEnabled: boolean;
   barWidth: number;
   forceLabel?: boolean;
+  resetFormatter?: (resetAt: Date | null) => string;
 }): string {
   const usageDisplay = formatUsagePercent(percent, colors);
-  const reset = formatResetTime(resetAt);
+  const reset = resetFormatter(resetAt);
   const styledLabel = label(windowLabel, colors);
 
   if (usageBarEnabled) {
@@ -324,4 +328,14 @@ function formatResetTime(resetAt: Date | null): string {
   const hours = String(resetAt.getHours()).padStart(2, '0');
   const minutes = String(resetAt.getMinutes()).padStart(2, '0');
   return `於 ${hours}:${minutes} 重置`;
+}
+
+function formatWeeklyResetTime(resetAt: Date | null): string {
+  if (!resetAt) return '';
+  const now = new Date();
+  if (resetAt.getTime() <= now.getTime()) return '';
+  const month = resetAt.getMonth() + 1;
+  const day = resetAt.getDate();
+  const hours = String(resetAt.getHours()).padStart(2, '0');
+  return `${month} 月 ${day} 號 ${hours}:00 重置`;
 }

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -1148,9 +1148,10 @@ test('renderSessionLine shows 7d reset countdown in text-only mode', () => {
 
   const line = stripAnsi(renderSessionLine(ctx));
   assert.ok(line.includes('Weekly 85%'), `should include 7d label and percentage: ${line}`);
+  const monthW = resetTime.getMonth() + 1;
+  const dayW = resetTime.getDate();
   const hhW = String(resetTime.getHours()).padStart(2, '0');
-  const mmW = String(resetTime.getMinutes()).padStart(2, '0');
-  assert.ok(line.includes(`於 ${hhW}:${mmW} 重置`), `should include 7d reset clock time in text-only mode: ${line}`);
+  assert.ok(line.includes(`${monthW} 月 ${dayW} 號 ${hhW}:00 重置`), `should include 7d reset date in text-only mode: ${line}`);
 });
 
 test('renderSessionLine respects sevenDayThreshold override', () => {
@@ -1235,9 +1236,10 @@ test('renderWeeklyUsageLine shows 7d reset countdown in text-only mode', () => {
 
   const line = stripAnsi(renderWeeklyUsageLine(ctx));
   assert.ok(line.includes('Weekly 85%'), `should include 7d text-only usage: ${line}`);
+  const monthW = resetTime.getMonth() + 1;
+  const dayW = resetTime.getDate();
   const hhW = String(resetTime.getHours()).padStart(2, '0');
-  const mmW = String(resetTime.getMinutes()).padStart(2, '0');
-  assert.ok(line.includes(`於 ${hhW}:${mmW} 重置`), `should include 7d reset clock time in text-only mode: ${line}`);
+  assert.ok(line.includes(`${monthW} 月 ${dayW} 號 ${hhW}:00 重置`), `should include 7d reset date in text-only mode: ${line}`);
 });
 
 test('renderWeeklyUsageLine translates weekly label when Chinese is enabled', () => {
@@ -1254,7 +1256,7 @@ test('renderWeeklyUsageLine translates weekly label when Chinese is enabled', ()
   try {
     const line = stripAnsi(renderWeeklyUsageLine(ctx) ?? '');
     assert.ok(line.includes('本周'));
-    assert.ok(line.includes('於') && line.includes('重置'));
+    assert.ok(line.includes('月') && line.includes('號') && line.includes('重置'));
   } finally {
     setLanguage('en');
   }
@@ -1274,9 +1276,10 @@ test('renderWeeklyUsageLine shows 7d reset countdown in bar mode', () => {
 
   const line = stripAnsi(renderWeeklyUsageLine(ctx));
   assert.ok(line.includes('85%'), `should include 7d percentage: ${line}`);
+  const monthB = resetTime.getMonth() + 1;
+  const dayB = resetTime.getDate();
   const hhB = String(resetTime.getHours()).padStart(2, '0');
-  const mmB = String(resetTime.getMinutes()).padStart(2, '0');
-  assert.ok(line.includes(`於 ${hhB}:${mmB} 重置`), `should include 7d reset clock time in bar mode: ${line}`);
+  assert.ok(line.includes(`${monthB} 月 ${dayB} 號 ${hhB}:00 重置`), `should include 7d reset date in bar mode: ${line}`);
 });
 
 test('renderWeeklyUsageLine shows weekly usage as independent line', () => {


### PR DESCRIPTION
## What was changed

Replaced the weekly usage reset time format from clock-only (於 HH:MM 重置) to a date-based format:

- Before reset: `{month} 月 {day} 號 HH:00 重置` (e.g. `4 月 14 號 16:00 重置`)
- At or past reset time: empty string (hides reset info)
- No data: empty string

This only applies to the **weekly (7-day)** reset time. The five-hour reset time retains its existing `於 HH:MM 重置` clock time format from override 8.

## Files modified

- `src/render/lines/weekly-usage.ts` — updated `formatResetTime` to produce date-based format
- `src/render/session-line.ts` — added `formatWeeklyResetTime` function and `resetFormatter` parameter to `formatUsageWindowPart`, passed the weekly formatter for all 7-day window calls
- `tests/render.test.js` — updated weekly reset time assertions to expect the new format

## Build result

`npm ci && npx tsc` — success. `npm run test:coverage` — all render/integration tests pass (12 pre-existing git test failures unrelated to this change).