### PR TITLE
override: add zh-TW option to configure command

### DIFF
--- a/commands/configure.md
+++ b/commands/configure.md
@@ -57,8 +57,9 @@ Questions: **Turn Off → Turn On → Git Style → Layout/Reset → Language �
 - options:
   - "English (Recommended)" - Default, simplest onboarding path
   - "中文" - Show HUD labels and status text in Chinese
+  - "繁體中文（台灣）" - Show HUD labels and status text in Traditional Chinese (Taiwan)
 
-Save as `language: "en"` or `language: "zh"`.
+Save as `language: "en"`, `language: "zh"`, or `language: "zh-TW"`.
 
 ### Q4: Turn Off (based on chosen preset)
 - header: "Turn Off"
@@ -164,10 +165,12 @@ Info items (Counts, Tokens, Usage, Speed, Duration) can be turned off via "Reset
   - "Keep current" - No change
   - "English (Recommended)" - Use English HUD labels
   - "中文" - Use Chinese HUD labels
+  - "繁體中文（台灣）" - Use Traditional Chinese (Taiwan) HUD labels
 
 If user chooses "Keep current", leave `language` unchanged.
 If user chooses "English (Recommended)", save `language: "en"`.
 If user chooses "中文", save `language: "zh"`.
+If user chooses "繁體中文（台灣）", save `language: "zh-TW"`.
 
 ### Q6: Custom Line (optional)
 - header: "Custom Line"
@@ -218,6 +221,7 @@ If user chooses "Remove", set `display.customLine` to `""` in config.
 |--------|--------|
 | English (Recommended) | `language: "en"` |
 | 中文 | `language: "zh"` |
+| 繁體中文（台灣） | `language: "zh-TW"` |
 
 ---
 


### PR DESCRIPTION
## Summary

- Added `繁體中文（台灣）` as a language option in the configure command's guided flow
- Updated **Flow A Q3** (new user language selection) to include zh-TW
- Updated **Flow B Q5** (existing config language update) to include zh-TW
- Updated the **Language Mapping** reference table

## Files Modified

- `commands/configure.md` — added zh-TW option to both new-user and update-config language questions, and to the language mapping table

## Build Result

TypeScript build (`npx tsc`) passes with no errors. No test changes needed — this override modifies only the configure command markdown. The zh-TW locale itself was already registered in the i18n system (override 6).

## Override Reference

Override 12 from `.unpxre/overrides.md`

https://claude.ai/code/session_013mSSYSPNjcpXgNen33VDq8