### PR TITLE
override: add separators toggle to configure command

### DIFF
--- a/commands/configure.md
+++ b/commands/configure.md
@@ -77,6 +77,7 @@ Save as `language: "en"` or `language: "zh"`.
   - "Session duration" - ⏱️ 5m
   - "Session name" - fix-auth-bug (session slug or custom title)
   - "Session tokens" - Tokens 12.8M (in: 7k, out: 28k, cache: 12.8M)
+  - "Separators" - horizontal line between info and activity
 
 ### Q5: Turn On (based on chosen preset)
 - header: "Turn On"
@@ -115,6 +116,7 @@ If user chooses "Enter custom text", use AskUserQuestion to get their text. Save
   - "Session name" - fix-auth-bug (session slug or custom title)
   - "Session tokens" - Tokens 12.8M (in: 7k, out: 28k, cache: 12.8M)
   - "Usage bar style" - ██░░ 25% visual bar (only if usageBarEnabled is true)
+  - "Separators" - horizontal line between info and activity (only if showSeparators is true)
 
 If more than 4 items ON, show Activity items (Tools, Agents, Todos, Project, Git) first.
 Info items (Counts, Tokens, Usage, Speed, Duration) can be turned off via "Reset to Minimal" in Q4.
@@ -132,6 +134,7 @@ Info items (Counts, Tokens, Usage, Speed, Duration) can be turned off via "Reset
   - "Session name" - fix-auth-bug (session slug or custom title)
   - "Session tokens" - Tokens 12.8M (in: 7k, out: 28k, cache: 12.8M)
   - "Session duration" - ⏱️ 5m
+  - "Separators" - horizontal line between info and activity (only if showSeparators is false)
 
 ### Q3: Git Style (only if Git is currently enabled)
 - header: "Git Style"
@@ -250,6 +253,7 @@ If user chooses "Remove", set `display.customLine` to `""` in config.
 | Session duration | `display.showDuration` |
 | Session tokens | `display.showSessionTokens` |
 | Custom line | `display.customLine` |
+| Separators | `showSeparators` |
 
 **Always true (not configurable):**
 - `display.showModel: true`


### PR DESCRIPTION
## Summary

- Added "Separators" as a toggleable option in the configure command
- **Flow A Q4** (Turn Off): added "Separators" — horizontal line between info and activity
- **Flow A Q5** (Turn On): inherits from same list (filtered to OFF items)
- **Flow B Q1** (Turn Off): added "Separators" (only shown if `showSeparators` is true)
- **Flow B Q2** (Turn On): added "Separators" (only shown if `showSeparators` is false)
- Added `showSeparators` to the Element Mapping reference table

## Files Modified

- `commands/configure.md` — added Separators option to Turn On/Turn Off questions in both flows and the element mapping table

## Build Result

TypeScript build (`npx tsc`) passes with no errors. No test changes needed — this override modifies only the configure command markdown. The `showSeparators` config key already exists in the HudConfig type and is fully functional.

## Override Reference

Override 13 from `.unpxre/overrides.md`

https://claude.ai/code/session_013mSSYSPNjcpXgNen33VDq8