### PR TITLE
override: clear resetsIn translation for zh-TW

### DIFF
--- a/src/i18n/zh-TW.ts
+++ b/src/i18n/zh-TW.ts
@@ -17,7 +17,7 @@ export const zhTW: Messages = {
 
   // Format
   "format.resets": "重置於",
-  "format.resetsIn": "重置剩餘",
+  "format.resetsIn": "",
   "format.in": "輸入",
   "format.cache": "快取",
   "format.out": "輸出",


### PR DESCRIPTION
## What was changed

- Set `format.resetsIn` to empty string `""` in the zh-TW locale file
- The reset time values already contain full descriptive text (e.g. `於 14:30 重置`, `4 月 15 號 09:00 重置`), so the `resetsIn` prefix is redundant and would result in duplicated text

## Files modified

- `src/i18n/zh-TW.ts` — changed `"format.resetsIn": "重置剩餘"` to `"format.resetsIn": ""`