### PR TITLE
override: replace parentheses with separator for reset time

### DIFF
--- a/src/render/lines/usage.ts
+++ b/src/render/lines/usage.ts
@@ -79,13 +79,13 @@ function formatUsageWindowPart({
 
   if (usageBarEnabled) {
     const body = reset
-      ? `${quotaBar(percent ?? 0, barWidth, colors)} ${usageDisplay} (${t("format.resetsIn")} ${reset})`
+      ? `${quotaBar(percent ?? 0, barWidth, colors)} ${usageDisplay} │ ${reset}`
       : `${quotaBar(percent ?? 0, barWidth, colors)} ${usageDisplay}`;
     return forceLabel ? `${styledLabel}  ${body}` : body;
   }
 
   return reset
-    ? `${styledLabel} ${usageDisplay} (${t("format.resetsIn")} ${reset})`
+    ? `${styledLabel} ${usageDisplay} │ ${reset}`
     : `${styledLabel} ${usageDisplay}`;
 }
 

--- a/src/render/lines/weekly-usage.ts
+++ b/src/render/lines/weekly-usage.ts
@@ -34,13 +34,13 @@ export function renderWeeklyUsageLine(ctx: RenderContext): string | null {
 
   if (usageBarEnabled) {
     const body = reset
-      ? `${quotaBar(sevenDay, barWidth, colors)} ${usageDisplay} (${t("format.resetsIn")} ${reset})`
+      ? `${quotaBar(sevenDay, barWidth, colors)} ${usageDisplay} │ ${reset}`
       : `${quotaBar(sevenDay, barWidth, colors)} ${usageDisplay}`;
     return `${weeklyLabel}  ${body}`;
   }
 
   return reset
-    ? `${weeklyLabel} ${usageDisplay} (${t("format.resetsIn")} ${reset})`
+    ? `${weeklyLabel} ${usageDisplay} │ ${reset}`
     : `${weeklyLabel} ${usageDisplay}`;
 }
 

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -309,13 +309,13 @@ function formatUsageWindowPart({
 
   if (usageBarEnabled) {
     const body = reset
-      ? `${quotaBar(percent ?? 0, barWidth, colors)} ${usageDisplay} (${reset} / ${windowLabel})`
+      ? `${quotaBar(percent ?? 0, barWidth, colors)} ${usageDisplay} │ ${reset}`
       : `${quotaBar(percent ?? 0, barWidth, colors)} ${usageDisplay}`;
     return forceLabel ? `${styledLabel}  ${body}` : body;
   }
 
   return reset
-    ? `${styledLabel} ${usageDisplay} (${t('format.resetsIn')} ${reset})`
+    ? `${styledLabel} ${usageDisplay} │ ${reset}`
     : `${styledLabel} ${usageDisplay}`;
 }
 

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -1150,7 +1150,7 @@ test('renderSessionLine shows 7d reset countdown in text-only mode', () => {
   assert.ok(line.includes('Weekly  85 %'), `should include 7d label and percentage: ${line}`);
   const hhW = String(resetTime.getHours()).padStart(2, '0');
   const mmW = String(resetTime.getMinutes()).padStart(2, '0');
-  assert.ok(line.includes(`於 ${hhW}:${mmW} 重置`), `should include 7d reset clock time in text-only mode: ${line}`);
+  assert.ok(line.includes(`│ 於 ${hhW}:${mmW} 重置`), `should include 7d reset clock time in text-only mode: ${line}`);
 });
 
 test('renderSessionLine respects sevenDayThreshold override', () => {


### PR DESCRIPTION
## What was changed

- Replaced parentheses `(resetsIn resetTime)` with `│ resetTime` separator format for reset time display
- Applied to all usage lines: five-hour usage, weekly usage, and compact session line
- Updated test assertion for 7d reset time text-only mode

## Files modified

- `src/render/lines/usage.ts` — replaced `(${t("format.resetsIn")} ${reset})` with `│ ${reset}` in bar and text modes
- `src/render/lines/weekly-usage.ts` — same replacement for weekly usage line
- `src/render/session-line.ts` — replaced `(${reset} / ${windowLabel})` and `(${t('format.resetsIn')} ${reset})` with `│ ${reset}`
- `tests/render.test.js` — updated 7d reset text-only assertion to match new format