### PR TITLE
override: replace parens with separator in compact usage window

### DIFF
--- a/src/render/lines/usage.ts
+++ b/src/render/lines/usage.ts
@@ -103,7 +103,7 @@ function formatCompactWindowPart(
   const reset = formatResetTime(resetAt, timeFormat);
   const styledLabel = label(`${windowLabel}:`, colors);
   return reset
-    ? `${styledLabel} ${usageDisplay} ${label(`(${reset})`, colors)}`
+    ? `${styledLabel} ${usageDisplay} │ ${reset}`
     : `${styledLabel} ${usageDisplay}`;
 }
 


### PR DESCRIPTION
Override 13 directs all usage lines that show reset time to use a `│` separator instead of parentheses, but `formatCompactWindowPart` in the usage line (used when `usageCompact: true`) still wrapped the reset time in `(...)`. The sibling function in `session-line.ts` already used the separator format, so this aligns the two compact-mode renderers.

## Files modified

- `src/render/lines/usage.ts` — `formatCompactWindowPart` now emits ` │ {reset}` instead of ` ({reset})`.

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZUwaQoD5Edrpv3P12PGEi)_