### PR TITLE
override: remove showResetLabel/resetsKey dead code

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,6 @@ Chinese HUD labels are available as an explicit opt-in. English stays the defaul
 | `display.showUsage` | boolean | true | Show Claude subscriber usage limits when available |
 | `display.usageBarEnabled` | boolean | true | Display usage as visual bar instead of text |
 | `display.usageCompact` | boolean | false | Display usage in a shorter text form such as `5h: 25% (1h 30m)`; takes precedence over `display.usageBarEnabled` |
-| `display.showResetLabel` | boolean | true | Show the `resets in` prefix before usage countdowns |
 | `display.timeFormat` | `relative` \| `absolute` \| `both` | `relative` | How reset times are shown in usage windows: countdown only (`resets in 2h 30m`), wall-clock time (`resets at 14:30`), or both (`resets in 2h 30m, at 14:30`) |
 | `display.sevenDayThreshold` | 0-100 | 80 | Show 7-day usage when >= threshold (0 = always) |
 | `display.externalUsagePath` | string | `""` | Optional path to a local usage snapshot file used only when stdin `rate_limits` are missing |
@@ -235,8 +234,6 @@ To disable, set `display.showUsage` to `false`.
 Reset times use relative countdowns by default. Set `display.timeFormat` to `absolute` for wall-clock
 times or `both` to show both forms. This setting is manual-only today; `/claude-hud:configure`
 preserves it without editing it.
-
-Set `display.showResetLabel` to `false` if you want shorter usage countdowns such as `(3h 17m)` instead of `(resets in 3h 17m)`.
 
 Set `display.usageCompact` to `true` if you want the shorter usage-only form, for example `5h: 25% (1h 30m)`. Compact usage takes precedence over `display.usageBarEnabled`.
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -94,7 +94,6 @@ export interface HudConfig {
     showTokenBreakdown: boolean;
     showUsage: boolean;
     usageBarEnabled: boolean;
-    showResetLabel: boolean;
     usageCompact: boolean;
     showTools: boolean;
     showAgents: boolean;
@@ -152,7 +151,6 @@ export const DEFAULT_CONFIG: HudConfig = {
     showTokenBreakdown: true,
     showUsage: true,
     usageBarEnabled: true,
-    showResetLabel: true,
     usageCompact: false,
     showTools: false,
     showAgents: false,
@@ -469,9 +467,6 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     usageBarEnabled: typeof migrated.display?.usageBarEnabled === 'boolean'
       ? migrated.display.usageBarEnabled
       : DEFAULT_CONFIG.display.usageBarEnabled,
-    showResetLabel: typeof migrated.display?.showResetLabel === 'boolean'
-      ? migrated.display.showResetLabel
-      : DEFAULT_CONFIG.display.showResetLabel,
     usageCompact: typeof migrated.display?.usageCompact === 'boolean'
       ? migrated.display.usageCompact
       : DEFAULT_CONFIG.display.usageCompact,

--- a/src/render/lines/usage.ts
+++ b/src/render/lines/usage.ts
@@ -29,8 +29,6 @@ export function renderUsageLine(
 
   const usageLabel = progressLabel("label.usage", colors, alignLabels);
   const timeFormat: TimeFormatMode = display?.timeFormat ?? 'relative';
-  const showResetLabel = display?.showResetLabel ?? true;
-  const resetsKey = timeFormat === 'absolute' ? "format.resets" : "format.resetsIn";
   const usageCompact = display?.usageCompact ?? false;
 
   const threshold = display?.usageThreshold ?? 0;
@@ -71,7 +69,6 @@ export function renderUsageLine(
       usageBarEnabled,
       barWidth,
       timeFormat,
-      showResetLabel,
       forceLabel: true,
       alignLabels,
     });
@@ -86,7 +83,6 @@ export function renderUsageLine(
     usageBarEnabled,
     barWidth,
     timeFormat,
-    showResetLabel,
   });
 
   return `${usageLabel} ${fiveHourPart}`;
@@ -128,7 +124,6 @@ function formatUsageWindowPart({
   usageBarEnabled,
   barWidth,
   timeFormat = 'relative',
-  showResetLabel,
   forceLabel = false,
   alignLabels = false,
 }: {
@@ -140,7 +135,6 @@ function formatUsageWindowPart({
   usageBarEnabled: boolean;
   barWidth: number;
   timeFormat?: TimeFormatMode;
-  showResetLabel: boolean;
   forceLabel?: boolean;
   alignLabels?: boolean;
 }): string {
@@ -149,7 +143,6 @@ function formatUsageWindowPart({
   const styledLabel = labelKey
     ? progressLabel(labelKey, colors, alignLabels)
     : label(windowLabel, colors);
-  const resetsKey = timeFormat === 'absolute' ? "format.resets" : "format.resetsIn";
 
   const resetSuffix = reset ? `│ ${reset}` : "";
 

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -38,7 +38,6 @@ export function renderSessionLine(ctx: RenderContext): string {
 
   const parts: string[] = [];
   const timeFormat: TimeFormatMode = display?.timeFormat ?? 'relative';
-  const resetsKey = timeFormat === 'absolute' ? 'format.resets' : 'format.resetsIn';
   const contextValueMode = display?.contextValue ?? 'percent';
   const contextValue = formatContextValue(ctx, percent, contextValueMode);
   const contextValueDisplay = `${getContextColor(percent, colors, contextThresholds)}${contextValue}${RESET}`;
@@ -169,7 +168,6 @@ export function renderSessionLine(ctx: RenderContext): string {
   // Usage limits display (shown when enabled in config, respects usageThreshold)
   if (display?.showUsage !== false && ctx.usageData && !shouldHideUsage(ctx.stdin)) {
     const usageCompact = display?.usageCompact ?? false;
-    const showResetLabel = display?.showResetLabel ?? true;
 
     {
       const usageThreshold = display?.usageThreshold ?? 0;
@@ -205,7 +203,6 @@ export function renderSessionLine(ctx: RenderContext): string {
             usageBarEnabled,
             barWidth,
             timeFormat,
-            showResetLabel,
             forceLabel: true,
           });
           parts.push(weeklyOnlyPart);
@@ -218,7 +215,6 @@ export function renderSessionLine(ctx: RenderContext): string {
             usageBarEnabled,
             barWidth,
             timeFormat,
-            showResetLabel,
           });
 
           const sevenDayThreshold = display?.sevenDayThreshold ?? 80;
@@ -231,7 +227,6 @@ export function renderSessionLine(ctx: RenderContext): string {
               usageBarEnabled,
               barWidth,
               timeFormat,
-              showResetLabel,
               forceLabel: true,
             });
             parts.push(`${label(t('label.usage'), colors)} ${fiveHourPart}`);
@@ -362,7 +357,6 @@ function formatUsageWindowPart({
   usageBarEnabled,
   barWidth,
   timeFormat = 'relative',
-  showResetLabel,
   forceLabel = false,
 }: {
   label: string;
@@ -372,14 +366,11 @@ function formatUsageWindowPart({
   usageBarEnabled: boolean;
   barWidth: number;
   timeFormat?: TimeFormatMode;
-  showResetLabel: boolean;
   forceLabel?: boolean;
 }): string {
   const usageDisplay = formatUsagePercent(percent, colors);
   const reset = formatResetTime(resetAt, timeFormat);
   const styledLabel = label(windowLabel, colors);
-  // "resets in X" for relative/both; "resets X" for absolute (avoids "resets in at 14:30")
-  const resetsKey = timeFormat === 'absolute' ? 'format.resets' : 'format.resetsIn';
 
   if (usageBarEnabled) {
     const body = reset

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -55,7 +55,7 @@ function baseContext() {
       pathLevels: 1,
       elementOrder: ['project', 'usage', 'weeklyUsage', 'context', 'promptCache', 'memory', 'environment', 'tools', 'agents', 'todos'],
       gitStatus: { enabled: true, showDirty: true, showAheadBehind: false, showFileStats: false, branchOverflow: 'truncate', pushWarningThreshold: 0, pushCriticalThreshold: 0 },
-      display: { showModel: true, showProject: true, showContextBar: true, contextValue: 'percent', showConfigCounts: true, showCost: false, showDuration: true, showSpeed: false, showTokenBreakdown: true, showUsage: true, usageBarEnabled: false, showResetLabel: true, showTools: true, showAgents: true, showTodos: true, showSessionTokens: false, showSessionName: false, showClaudeCodeVersion: false, showMemoryUsage: false, showPromptCache: false, promptCacheTtlSeconds: 300, showOutputStyle: false, mergeGroups: [['context', 'usage']], autocompactBuffer: 'enabled', usageThreshold: 0, sevenDayThreshold: 80, environmentThreshold: 0, customLine: '' },
+      display: { showModel: true, showProject: true, showContextBar: true, contextValue: 'percent', showConfigCounts: true, showCost: false, showDuration: true, showSpeed: false, showTokenBreakdown: true, showUsage: true, usageBarEnabled: false, showTools: true, showAgents: true, showTodos: true, showSessionTokens: false, showSessionName: false, showClaudeCodeVersion: false, showMemoryUsage: false, showPromptCache: false, promptCacheTtlSeconds: 300, showOutputStyle: false, mergeGroups: [['context', 'usage']], autocompactBuffer: 'enabled', usageThreshold: 0, sevenDayThreshold: 80, environmentThreshold: 0, customLine: '' },
       colors: {
         context: 'green',
         usage: 'brightBlue',
@@ -1395,7 +1395,6 @@ test('renderWeeklyUsageLine shows reset time with separator in text-only mode', 
   const ctx = baseContext();
   const resetTime = new Date(Date.now() + (28 * 60 * 60 * 1000));
   ctx.config.display.usageBarEnabled = false;
-  ctx.config.display.showResetLabel = false;
   ctx.usageData = {
     planName: 'Pro',
     fiveHour: 45,
@@ -1443,23 +1442,6 @@ test('renderWeeklyUsageLine shows 7d reset countdown in bar mode', () => {
   const line = stripAnsi(renderWeeklyUsageLine(ctx));
   assert.ok(line.includes('85 %'), `should include 7d percentage: ${line}`);
   assert.ok(line.includes('│ 1d 4h'), `should include 7d reset countdown in bar mode: ${line}`);
-});
-
-test('renderWeeklyUsageLine can hide reset label in bar mode', () => {
-  const ctx = baseContext();
-  const resetTime = new Date(Date.now() + (28 * 60 * 60 * 1000));
-  ctx.config.display.usageBarEnabled = true;
-  ctx.config.display.showResetLabel = false;
-  ctx.usageData = {
-    planName: 'Pro',
-    fiveHour: 45,
-    sevenDay: 85,
-    fiveHourResetAt: null,
-    sevenDayResetAt: resetTime,
-  };
-
-  const line = stripAnsi(renderWeeklyUsageLine(ctx));
-  assert.ok(line.includes('│ 1d 4h'), `should show reset time with separator in bar mode: ${line}`);
 });
 
 test('renderUsageLine shows weekly-only usage without a ghost 5h section', () => {


### PR DESCRIPTION
Override 13 directs the sync agent to remove the `showResetLabel` / `resetsKey` logic so the reset time is always shown bare with the `│` separator. The rendering switch was already done in earlier PRs, but the config knob and the unused `resetsKey` variables were left behind as dead code.

This PR finishes the cleanup:

- Drop `showResetLabel` from the `HudConfig` type, `DEFAULT_CONFIG`, and the migration validator
- Remove the unused `showResetLabel` plumbing and `resetsKey` locals from `renderUsageLine` / `formatUsageWindowPart` (`src/render/lines/usage.ts`) and from `renderSessionLine` / `formatUsageWindowPart` (`src/render/session-line.ts`)
- Drop the now-meaningless `showResetLabel` references in `tests/render.test.js`, including the redundant "can hide reset label in bar mode" case
- Remove the README documentation for the deleted setting

## Files modified

- `src/config.ts`
- `src/render/lines/usage.ts`
- `src/render/session-line.ts`
- `tests/render.test.js`
- `README.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_01GGtqwEdkrJN2pfrt3yTMdq)_