### PR TITLE
fix: update lite preset layout to correct merge order

### DIFF
--- a/commands/Unpxre.md
+++ b/commands/Unpxre.md
@@ -129,6 +129,7 @@ Use this config if the user chose "精簡版 (Lite)" in Step 5:
   "lineLayout": "expanded",
   "showSeparators": false,
   "language": "zh-TW",
+  "elementOrder": ["project", "context", "usage", "weeklyUsage"],
   "display": {
     "showModel": true,
     "showContextBar": true,
@@ -141,7 +142,7 @@ Use this config if the user chose "精簡版 (Lite)" in Step 5:
     "showSpeed": false,
     "showUsage": true,
     "usageBarEnabled": true,
-    "showDuration": false,
+    "showDuration": true,
     "showSessionName": false,
     "showSessionTokens": false,
     "customLine": "",
@@ -153,7 +154,7 @@ Use this config if the user chose "精簡版 (Lite)" in Step 5:
     "enabled": true,
     "showDirty": true,
     "showAheadBehind": false,
-    "showFileStats": false
+    "showFileStats": true
   }
 }
 ```


### PR DESCRIPTION
## Summary
- 精簡版加入 `elementOrder: ["project", "context", "usage", "weeklyUsage"]`，讓 context+usage 相鄰使 mergeGroups 能正確合併
- 啟用 `showDuration` 和 `showFileStats` 與完整版第一行一致
- 平常兩行，週用量超過閾值時允許第三行

## 問題
預設 elementOrder 把 weeklyUsage 夾在 usage 和 context 之間，導致 mergeGroups 無法合併，精簡版實際輸出變成四行而非預期的兩行。

https://claude.ai/code/session_01AF4Nuf5mE3Uy9wjqjWsXLK

---
_Generated by [Claude Code](https://claude.ai/code/session_01AF4Nuf5mE3Uy9wjqjWsXLK)_