### PR TITLE
fix: add COLUMNS width detection to Unpxre command template

### DIFF
--- a/.unpxre/overrides.md
+++ b/.unpxre/overrides.md
@@ -383,6 +383,16 @@ before the `contains(..., '@claude')` check.
 Maintain `commands/Unpxre.md` — a setup command that configures
 statusLine and writes the recommended config in one step.
 
+The statusLine command template MUST include COLUMNS width detection
+(matching upstream setup.md):
+```
+cols=$(stty size </dev/tty 2>/dev/null | awk '{print $2}');
+export COLUMNS=$(( ${cols:-120} > 4 ? ${cols:-120} - 4 : 1 ));
+```
+This is required because Claude Code pipes stdout, making
+`process.stdout.columns` unavailable. Without this, the HUD falls
+back to `maxWidth` config and cannot adapt to real terminal width.
+
 The command uses `AskUserQuestion` to let the user choose between
 two presets before writing config:
 

--- a/commands/Unpxre.md
+++ b/commands/Unpxre.md
@@ -30,14 +30,20 @@ Determine source file:
 
 ## Step 2: Generate statusLine Command
 
+The command exports `COLUMNS` so the HUD knows the real terminal width.
+Claude Code pipes the subprocess stdout, so `process.stdout.columns` is
+unavailable at runtime. `stty size </dev/tty` reads from the controlling
+terminal. The `- 4` accounts for Claude Code's input area padding
+(2 columns on each side).
+
 **When runtime is bun** (add `--env-file /dev/null`):
 ```
-bash -c 'plugin_dir=$(ls -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/claude-hud/claude-hud/*/ 2>/dev/null | awk -F/ '"'"'{ print $(NF-1) "\t" $(0) }'"'"' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-); exec "{RUNTIME_PATH}" --env-file /dev/null "${plugin_dir}{SOURCE}"'
+bash -c 'cols=$(stty size </dev/tty 2>/dev/null | awk '"'"'{print $2}'"'"'); export COLUMNS=$(( ${cols:-120} > 4 ? ${cols:-120} - 4 : 1 )); plugin_dir=$(ls -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/claude-hud/claude-hud/*/ 2>/dev/null | awk -F/ '"'"'{ print $(NF-1) "\t" $(0) }'"'"' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-); exec "{RUNTIME_PATH}" --env-file /dev/null "${plugin_dir}{SOURCE}"'
 ```
 
 **When runtime is node**:
 ```
-bash -c 'plugin_dir=$(ls -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/claude-hud/claude-hud/*/ 2>/dev/null | awk -F/ '"'"'{ print $(NF-1) "\t" $(0) }'"'"' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-); exec "{RUNTIME_PATH}" "${plugin_dir}{SOURCE}"'
+bash -c 'cols=$(stty size </dev/tty 2>/dev/null | awk '"'"'{print $2}'"'"'); export COLUMNS=$(( ${cols:-120} > 4 ? ${cols:-120} - 4 : 1 )); plugin_dir=$(ls -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/claude-hud/claude-hud/*/ 2>/dev/null | awk -F/ '"'"'{ print $(NF-1) "\t" $(0) }'"'"' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-); exec "{RUNTIME_PATH}" "${plugin_dir}{SOURCE}"'
 ```
 
 ## Step 3: Test Command


### PR DESCRIPTION
## Summary
- Unpxre.md 的 statusLine 指令模板缺少 COLUMNS 寬度偵測，導致 HUD 無法得知真實終端寬度
- 加入 `stty size </dev/tty` 偵測（與上游 setup.md 一致），每次調用動態取得當前終端寬度
- 更新 Override 16 描述，記錄此為必要行為

## 問題
Claude Code pipe 了 statusLine 的 stdout，使 `process.stdout.columns` 永遠 undefined。沒有 COLUMNS 環境變數時，HUD 只能 fallback 到 `maxWidth: 120` 硬編碼值，無法適應實際終端寬度。

## 修正後
重新執行 `/claude-hud:Unpxre` 會寫入帶寬度偵測的新指令，HUD 可動態適應終端寬度變化。

https://claude.ai/code/session_01AF4Nuf5mE3Uy9wjqjWsXLK

---
_Generated by [Claude Code](https://claude.ai/code/session_01AF4Nuf5mE3Uy9wjqjWsXLK)_