### PR TITLE
override: add zh-TW option to configure command

### DIFF
--- a/commands/configure.md
+++ b/commands/configure.md
@@ -58,9 +58,10 @@ Questions: **Turn Off → Turn On → Git Style → Layout/Reset → Language �
 - multiSelect: false
 - options:
   - "English (Recommended)" - Default, simplest onboarding path
-  - "中文" - Show HUD labels and status text in Chinese
+  - "中文" - Show HUD labels and status text in Simplified Chinese
+  - "繁體中文（台灣）" - Show HUD labels and status text in Traditional Chinese
 
-Save as `language: "en"` or `language: "zh"`.
+Save as `language: "en"`, `language: "zh"`, or `language: "zh-TW"`.
 
 ### Q4: Turn Off (based on chosen preset)
 - header: "Turn Off"
@@ -163,16 +164,18 @@ Info items (Counts, Tokens, Usage, Speed, Duration) can be turned off via "Reset
 
 ### Q5: Language
 - header: "Language"
-- question: "Update HUD label language? (current: '{English or 中文}')"
+- question: "Update HUD label language? (current: '{English, 中文, or 繁體中文}')"
 - multiSelect: false
 - options:
   - "Keep current" - No change
   - "English (Recommended)" - Use English HUD labels
-  - "中文" - Use Chinese HUD labels
+  - "中文" - Use Simplified Chinese HUD labels
+  - "繁體中文（台灣）" - Use Traditional Chinese HUD labels
 
 If user chooses "Keep current", leave `language` unchanged.
 If user chooses "English (Recommended)", save `language: "en"`.
 If user chooses "中文", save `language: "zh"`.
+If user chooses "繁體中文（台灣）", save `language: "zh-TW"`.
 
 ### Q6: Custom Line (optional)
 - header: "Custom Line"
@@ -223,6 +226,7 @@ If user chooses "Remove", set `display.customLine` to `""` in config.
 |--------|--------|
 | English (Recommended) | `language: "en"` |
 | 中文 | `language: "zh"` |
+| 繁體中文（台灣） | `language: "zh-TW"` |
 
 ---
 


### PR DESCRIPTION
Add `繁體中文（台灣）` as a language option in both new user and update config flows.

Files modified: `commands/configure.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_01AF4Nuf5mE3Uy9wjqjWsXLK)_