### PR TITLE
override: add separators toggle to configure command

### DIFF
--- a/commands/configure.md
+++ b/commands/configure.md
@@ -81,6 +81,7 @@ Save as `language: "en"`, `language: "zh"`, or `language: "zh-TW"`.
   - "Session duration" - ⏱️ 5m
   - "Session name" - fix-auth-bug (session slug or custom title)
   - "Session tokens" - Tokens 12.8M (in: 7k, out: 28k, cache: 12.8M)
+  - "Separators" - Horizontal line between info and activity lines
 
 ### Q5: Turn On (based on chosen preset)
 - header: "Turn On"
@@ -260,6 +261,7 @@ If user chooses "Remove", set `display.customLine` to `""` in config.
 | Session duration | `display.showDuration` |
 | Session tokens | `display.showSessionTokens` |
 | Custom line | `display.customLine` |
+| Separators | `showSeparators` |
 
 **Always true (not configurable):**
 - `display.showModel: true`


### PR DESCRIPTION
Add "Separators" option to Turn On/Turn Off questions and element mapping table so users can enable/disable the separator line between info and activity lines.

Files modified: `commands/configure.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_01AF4Nuf5mE3Uy9wjqjWsXLK)_