### PR TITLE
feat: 新增 customLinePosition 設定控制自訂文字位置

### DIFF
--- a/commands/configure.md
+++ b/commands/configure.md
@@ -259,6 +259,7 @@ If user chooses "Remove", set `display.customLine` to `""` in config.
 | Session start date | `display.showSessionStartDate` |
 | Last response time | `display.showLastResponseAt` |
 | Custom line | `display.customLine` |
+| Custom line position | `display.customLinePosition` |
 
 **Always true (not configurable):**
 - `display.showModel: true`

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,6 +20,7 @@ export type GitBranchOverflowMode = 'truncate' | 'wrap';
  */
 export type ModelFormatMode = 'full' | 'compact' | 'short';
 export type TimeFormatMode = 'relative' | 'absolute' | 'both' | 'elapsed' | 'elapsedAndAbsolute';
+export type CustomLinePosition = 'first' | 'last';
 export type HudElement = 'project' | 'addedDirs' | 'context' | 'usage' | 'promptCache' | 'memory' | 'environment' | 'tools' | 'agents' | 'todos' | 'sessionTime';
 
 export type AddedDirsLayout = 'inline' | 'line';
@@ -134,6 +135,7 @@ export interface HudConfig {
     modelFormat: ModelFormatMode;
     modelOverride: string;
     customLine: string;
+    customLinePosition: CustomLinePosition;
     timeFormat: TimeFormatMode;
   };
   colors: HudColorOverrides;
@@ -201,6 +203,7 @@ export const DEFAULT_CONFIG: HudConfig = {
     modelFormat: 'full',
     modelOverride: '',
     customLine: '',
+    customLinePosition: 'last',
     timeFormat: 'relative',
   },
   colors: {
@@ -263,6 +266,10 @@ function validateTimeFormat(value: unknown): value is TimeFormatMode {
     || value === 'both'
     || value === 'elapsed'
     || value === 'elapsedAndAbsolute';
+}
+
+function validateCustomLinePosition(value: unknown): value is CustomLinePosition {
+  return value === 'first' || value === 'last';
 }
 
 function validateColorName(value: unknown): value is HudColorName {
@@ -617,6 +624,9 @@ export function mergeConfig(userConfig: Partial<HudConfig>): HudConfig {
     customLine: typeof migrated.display?.customLine === 'string'
       ? migrated.display.customLine.slice(0, 80)
       : DEFAULT_CONFIG.display.customLine,
+    customLinePosition: validateCustomLinePosition(migrated.display?.customLinePosition)
+      ? migrated.display.customLinePosition
+      : DEFAULT_CONFIG.display.customLinePosition,
     timeFormat: validateTimeFormat(migrated.display?.timeFormat)
       ? migrated.display.timeFormat
       : DEFAULT_CONFIG.display.timeFormat,

--- a/src/render/lines/project.ts
+++ b/src/render/lines/project.ts
@@ -55,6 +55,12 @@ export function renderProjectLine(ctx: RenderContext): string | null {
   const colors = ctx.config?.colors;
   const parts: string[] = [];
 
+  const customLine = display?.customLine;
+  const customLinePosition = display?.customLinePosition ?? 'last';
+  if (customLine && customLinePosition === 'first') {
+    parts.push(customColor(customLine, colors));
+  }
+
   if (display?.showModel !== false) {
     const model = formatModelName(getModelName(ctx.stdin), ctx.config?.display?.modelFormat, ctx.config?.display?.modelOverride);
     const providerLabel = getProviderLabel(ctx.stdin);
@@ -172,8 +178,7 @@ export function renderProjectLine(ctx: RenderContext): string | null {
     }
   }
 
-  const customLine = display?.customLine;
-  if (customLine) {
+  if (customLine && customLinePosition === 'last') {
     parts.push(customColor(customLine, colors));
   }
 

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -45,7 +45,13 @@ export function renderSessionLine(ctx: RenderContext): string {
   const contextValue = formatContextValue(ctx, percent, contextValueMode);
   const contextValueDisplay = `${getContextColor(percent, colors, contextThresholds)}${contextValue}${RESET}`;
 
-  // Model and context bar (FIRST)
+  const customLine = display?.customLine;
+  const customLinePosition = display?.customLinePosition ?? 'last';
+  if (customLine && customLinePosition === 'first') {
+    parts.push(customColor(customLine, colors));
+  }
+
+  // Model and context bar
   const providerLabel = getProviderLabel(ctx.stdin);
   const modelQualifier = providerLabel ?? undefined;
   let modelDisplay = modelQualifier ? `${model} | ${modelQualifier}` : model;
@@ -65,7 +71,7 @@ export function renderSessionLine(ctx: RenderContext): string {
     parts.push(contextValueDisplay);
   }
 
-  // Project path + git status (SECOND)
+  // Project path + git status
   let projectPart: string | null = null;
   if (display?.showProject !== false && ctx.stdin.cwd) {
     // Split by both Unix (/) and Windows (\) separators for cross-platform support
@@ -299,9 +305,7 @@ export function renderSessionLine(ctx: RenderContext): string {
     parts.push(label(ctx.extraLabel, colors));
   }
 
-  // Custom line (static user-defined text)
-  const customLine = display?.customLine;
-  if (customLine) {
+  if (customLine && customLinePosition === 'last') {
     parts.push(customColor(customLine, colors));
   }
 

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -254,6 +254,21 @@ test('mergeConfig preserves customLine and truncates long values', () => {
   assert.equal(config.display.customLine, customLine.slice(0, 80));
 });
 
+test('mergeConfig defaults customLinePosition to last', () => {
+  const config = mergeConfig({});
+  assert.equal(config.display.customLinePosition, 'last');
+});
+
+test('mergeConfig preserves explicit customLinePosition', () => {
+  const config = mergeConfig({ display: { customLinePosition: 'first' } });
+  assert.equal(config.display.customLinePosition, 'first');
+});
+
+test('mergeConfig falls back to last for invalid customLinePosition', () => {
+  const config = mergeConfig({ display: { customLinePosition: 'middle' } });
+  assert.equal(config.display.customLinePosition, 'last');
+});
+
 test('mergeConfig defaults modelFormat to full', () => {
   const config = mergeConfig({});
   assert.equal(config.display.modelFormat, 'full');

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -473,6 +473,28 @@ test('renderSessionLine includes customLine when configured', () => {
   assert.ok(line.includes('Ship it'));
 });
 
+test('renderSessionLine places customLine before model badge when position is first', () => {
+  const ctx = baseContext();
+  ctx.config.display.customLine = 'prod-server';
+  ctx.config.display.customLinePosition = 'first';
+  const line = stripAnsi(renderSessionLine(ctx));
+  const customIdx = line.indexOf('prod-server');
+  const modelIdx = line.indexOf('[Opus]');
+  assert.ok(customIdx >= 0, 'should include custom line');
+  assert.ok(modelIdx >= 0, 'should include model badge');
+  assert.ok(customIdx < modelIdx, `custom line (${customIdx}) should appear before model badge (${modelIdx})`);
+});
+
+test('renderSessionLine places customLine at end when position is last', () => {
+  const ctx = baseContext();
+  ctx.config.display.customLine = 'prod-server';
+  ctx.config.display.customLinePosition = 'last';
+  const line = stripAnsi(renderSessionLine(ctx));
+  const customIdx = line.indexOf('prod-server');
+  const modelIdx = line.indexOf('[Opus]');
+  assert.ok(customIdx > modelIdx, 'custom line should appear after model badge when position is last');
+});
+
 test('renderSessionLine applies modelFormat compact', () => {
   const ctx = baseContext();
   ctx.stdin.model = { display_name: 'Opus 4.6 (1M context)' };
@@ -570,6 +592,30 @@ test('renderProjectLine includes customLine when configured', () => {
   ctx.config.display.customLine = 'Stay sharp';
   const line = stripAnsi(renderProjectLine(ctx) ?? '');
   assert.ok(line.includes('Stay sharp'));
+});
+
+test('renderProjectLine places customLine before model badge when position is first', () => {
+  const ctx = baseContext();
+  ctx.stdin.cwd = '/tmp/my-project';
+  ctx.config.display.customLine = 'prod-server';
+  ctx.config.display.customLinePosition = 'first';
+  const line = stripAnsi(renderProjectLine(ctx) ?? '');
+  const customIdx = line.indexOf('prod-server');
+  const modelIdx = line.indexOf('[Opus]');
+  assert.ok(customIdx >= 0, 'should include custom line');
+  assert.ok(modelIdx >= 0, 'should include model badge');
+  assert.ok(customIdx < modelIdx, `custom line (${customIdx}) should appear before model badge (${modelIdx})`);
+});
+
+test('renderProjectLine places customLine at end when position is last', () => {
+  const ctx = baseContext();
+  ctx.stdin.cwd = '/tmp/my-project';
+  ctx.config.display.customLine = 'prod-server';
+  ctx.config.display.customLinePosition = 'last';
+  const line = stripAnsi(renderProjectLine(ctx) ?? '');
+  const customIdx = line.indexOf('prod-server');
+  const modelIdx = line.indexOf('[Opus]');
+  assert.ok(customIdx > modelIdx, 'custom line should appear after model badge when position is last');
 });
 
 test('renderProjectLine applies modelFormat compact (strips context suffix)', () => {


### PR DESCRIPTION
## Problem

`customLine` 固定渲染在 status line 的最後位置。當使用者透過多個終端機分頁或分割視窗管理多個 SSH session 時，常用 `customLine` 作為機器識別標記（如 `🖥️ prod-db-01`）。放在行尾，切換分頁時必須掃到最右邊才能辨識是哪個 session，尤其在快速切換時效率很低。

```
分頁 1: [Opus] │ api-service git:(main*) │ ⏱️ 5m │ 🖥️ prod-db-01
分頁 2: [Opus] │ api-service git:(deploy) │ ⏱️ 12m │ 🖥️ staging-01
        ← 視線從這裡開始                            在這裡才找到標記 →
```

## Solution

新增 `display.customLinePosition` 設定（`"first"` | `"last"`），預設 `"last"`。預設設定的使用者不受影響。不需要手動設定即可使用 — 未設定或設定無效值時自動使用預設值。

設為 `"first"` 時 customLine 渲染在行首（model badge 之前），切換分頁時第一眼就能辨識。與 `addedDirsLayout`、`gitBranchOverflow`、`toolNameOverflow` 等既有設定使用相同的小 enum 模式。

### SSH 多主機識別（每台主機各自設定 customLine）

```
分頁 1: 🖥️ prod-db-01 │ [Opus] │ api-service git:(main*) │ ⏱️ 5m
分頁 2: 🖥️ staging-01 │ [Opus] │ api-service git:(deploy) │ ⏱️ 12m
分頁 3: 🖥️ dev-local  │ [Opus] │ api-service git:(feat/auth) │ ⏱️ 2m
        ↑ 立即辨識
```

### 開發/正式環境區分（每台機器設定不同環境標記）

```
正式機: 🔴 PROD │ [Opus] │ my-project git:(main)
測試機: 🟡 STG  │ [Opus] │ my-project git:(release/v2)
開發機: 🟢 DEV  │ [Opus] │ my-project git:(feat/new-ui*)
```

### 設定方式

```json
{
  "display": {
    "customLine": "🖥️ prod-db-01",
    "customLinePosition": "first"
  }
}
```

注意：config 為全域設定（`~/.claude/plugins/claude-hud/config.json`），同一台機器上的所有 session 共用相同的 `customLine` 值。上述範例適用於 SSH 到不同主機的場景（每台主機有各自的 config）。

## Alternative

直接將 customLine 預設位置改為行首而不加設定項會更簡單，但會改變現有使用者的 customLine 位置。

## 變更檔案

- `src/config.ts` — `CustomLinePosition` 型別、驗證、合併邏輯
- `src/render/lines/project.ts` — expanded mode 位置邏輯
- `src/render/session-line.ts` — compact mode 位置邏輯
- `commands/configure.md` — 元素對照表
- `tests/config.test.js` — 預設值、明確設定、無效值 fallback
- `tests/render.test.js` — 兩種模式下的 first/last 位置驗證

## 對應上游 PR

[jarrodwatts/claude-hud#575](https://github.com/jarrodwatts/claude-hud/pull/575)

## Testing

- [x] `npm test`
- [x] `npm run build`

## Checklist

- [x] Tests updated or not needed
- [x] Docs updated if behavior changed