### PR TITLE
refactor: 將 sessionTokens 提升為可排序的 HudElement

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -20,7 +20,7 @@ export type GitBranchOverflowMode = 'truncate' | 'wrap';
  */
 export type ModelFormatMode = 'full' | 'compact' | 'short';
 export type TimeFormatMode = 'relative' | 'absolute' | 'both' | 'elapsed' | 'elapsedAndAbsolute';
-export type HudElement = 'project' | 'addedDirs' | 'context' | 'usage' | 'promptCache' | 'memory' | 'environment' | 'tools' | 'agents' | 'todos' | 'sessionTime';
+export type HudElement = 'project' | 'addedDirs' | 'context' | 'usage' | 'promptCache' | 'memory' | 'environment' | 'tools' | 'agents' | 'todos' | 'sessionTime' | 'sessionTokens';
 
 export type AddedDirsLayout = 'inline' | 'line';
 export type HudColorName =
@@ -64,6 +64,7 @@ export const DEFAULT_ELEMENT_ORDER: HudElement[] = [
   'agents',
   'todos',
   'sessionTime',
+  'sessionTokens',
 ];
 
 export const DEFAULT_MERGE_GROUPS: HudElement[][] = [

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -401,6 +401,8 @@ function renderElementLine(
       return display?.showTodos === false ? null : renderTodosLine(ctx);
     case 'sessionTime':
       return renderSessionTimeLine(ctx);
+    case 'sessionTokens':
+      return display?.showSessionTokens === false ? null : renderSessionTokensLine(ctx);
   }
 }
 
@@ -517,14 +519,6 @@ export function render(ctx: RenderContext): void {
   if (lineLayout === 'expanded') {
     const renderedLines = renderExpanded(ctx, terminalWidth);
     lines = renderedLines.map(({ line }) => line);
-
-    // Session token usage (cumulative)
-    if (ctx.config?.display?.showSessionTokens) {
-      const sessionTokensLine = renderSessionTokensLine(ctx);
-      if (sessionTokensLine) {
-        lines.push(sessionTokensLine);
-      }
-    }
 
     if (showSeparators) {
       const firstActivityIndex = renderedLines.findIndex(({ isActivity }) => isActivity);


### PR DESCRIPTION
## Problem

`sessionTokens` 目前不是 `HudElement`，而是在 `render()` 函數中以特殊邏輯直接 push 到輸出行。這導致它：

- 無法被 `elementOrder` 排序
- 無法被 `mergeGroups` 與其他元素合併到同一行
- 是唯一需要特殊處理的顯示項目，其餘都走 element 流程

相關上游 issue：[jarrodwatts/claude-hud#499](https://github.com/jarrodwatts/claude-hud/issues/499)

## Solution

將 `sessionTokens` 提升為正式的 `HudElement`，復用既有的 element 基礎建設：

1. `HudElement` type 加入 `'sessionTokens'`
2. `DEFAULT_ELEMENT_ORDER` 末尾加入（保持現有預設位置）
3. `renderElementLine()` 加入 `case 'sessionTokens'`（復用既有的 `renderSessionTokensLine`）
4. 從 `render()` 移除直接 push 的特殊邏輯

不需要新增任何基礎建設 — `KNOWN_ELEMENTS`、`validateElementOrder()`、`mergeGroups` 合併邏輯、`showSessionTokens` toggle 全部自動支援。

## Result

預設設定的使用者不受影響 — `sessionTokens` 在 `DEFAULT_ELEMENT_ORDER` 末尾，行為跟之前一樣。

提升後使用者可以：

| 操作 | 之前 | 之後 |
|---|---|---|
| 調整 sessionTokens 行順序 | ❌ | ✅ `elementOrder` |
| 跟其他元素合併同一行 | ❌ | ✅ `mergeGroups` |
| 隱藏 | ✅ | ✅（不變） |

### Config 範例

```json
{
  "elementOrder": ["project", "context", "usage", "sessionTokens", "tools"],
  "display": {
    "mergeGroups": [["context", "usage", "sessionTokens"]]
  }
}
```

```
[Opus] │ my-project git:(main*)
Context ████░░░░░░ 45% │ Usage ██░░░░░░░░ 25% │ Tokens 8.1M (in: 139k, out: 33k)
```

## 變更檔案

- `src/config.ts` — `HudElement` type 和 `DEFAULT_ELEMENT_ORDER` 加入 `sessionTokens`（+2 行）
- `src/render/index.ts` — `renderElementLine` 加 case，移除 `render()` 裡的特殊邏輯（+2 / -7 行）

## 向前相容性

- 現有 config 不需要修改
- 手動設定 `elementOrder` 但沒列 `sessionTokens` 的使用者 — sessionTokens 不顯示（跟其他 element 行為一致）
- `showSessionTokens` toggle 行為不變

## Testing

- [x] `npm test` — 599 pass
- [x] `npm run build`

## Checklist

- [x] Tests updated or not needed
- [x] Docs updated if behavior changed