### PR TITLE
override: add Traditional Chinese (zh-Hant) locale

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -265,7 +265,8 @@ function validateUsageValue(value: unknown): value is UsageValueMode {
 }
 
 function validateLanguage(value: unknown): value is Language {
-  return value === 'en' || value === 'zh' || value === 'zh-Hans';
+  return value === 'en' || value === 'zh' || value === 'zh-Hans'
+    || value === 'zh-Hant' || value === 'zh-TW';
 }
 
 function validateModelFormat(value: unknown): value is ModelFormatMode {

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,24 +1,29 @@
 import type { Language, MessageKey, Messages } from "./types.js";
 import { en } from "./en.js";
 import { zhHans } from "./zh-Hans.js";
+import { zhHant } from "./zh-Hant.js";
 
 export type { Language, MessageKey, Messages };
 
-type CanonicalLanguage = "en" | "zh-Hans";
+type CanonicalLanguage = "en" | "zh-Hans" | "zh-Hant";
 
 const locales: Record<CanonicalLanguage | "zh", Messages> = {
   en,
   zh: zhHans,
   "zh-Hans": zhHans,
+  "zh-Hant": zhHant,
 };
 
 // Resolve short language tags to canonical BCP 47 forms.
 // Based on CLDR likely subtags: zh → zh-Hans-CN
+// zh-TW is accepted as a region alias resolving to the Traditional script.
 // https://www.unicode.org/cldr/charts/latest/supplemental/likely_subtags.html
 const CANONICAL: Record<Language, CanonicalLanguage> = {
   "en": "en",
   "zh": "zh-Hans",
   "zh-Hans": "zh-Hans",
+  "zh-Hant": "zh-Hant",
+  "zh-TW": "zh-Hant",
 };
 
 let currentLanguage: Language = "en";
@@ -38,7 +43,8 @@ export function getCanonicalLanguage(): CanonicalLanguage {
 
 // https://www.unicode.org/reports/tr11/
 export function isCjkLanguage(): boolean {
-  return getCanonicalLanguage() === "zh-Hans";
+  const canon = getCanonicalLanguage();
+  return canon === "zh-Hans" || canon === "zh-Hant";
 }
 
 export function t(key: MessageKey): string {

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -34,4 +34,4 @@ export type MessageKey =
 
 export type Messages = Record<MessageKey, string>;
 
-export type Language = "en" | "zh" | "zh-Hans";
+export type Language = "en" | "zh" | "zh-Hans" | "zh-Hant" | "zh-TW";

--- a/src/i18n/zh-Hant.ts
+++ b/src/i18n/zh-Hant.ts
@@ -1,0 +1,40 @@
+import type { Messages } from "./types.js";
+
+export const zhHant: Messages = {
+  // Labels
+  "label.context": "上下文佔用",
+  "label.usage": "五小時上限",
+  "label.weekly": "每週使用量",
+  "label.approxRam": "記憶體用量",
+  "label.promptCache": "快取",
+  "label.rules": "規則",
+  "label.hooks": "hooks",
+  "label.estimatedCost": "估算",
+  "label.cost": "費用",
+  "label.tokens": "Tokens",
+  "label.sessionStarted": "工作階段開始",
+  "label.lastReply": "上次回覆",
+  "label.advisor": "顧問",
+
+  // Status
+  "status.limitReached": "已達上限",
+  "status.allTodosComplete": "全部完成",
+  "status.expired": "已過期",
+
+  // Format
+  "format.resets": "重置於",
+  "format.resetsIn": "",
+  "format.at": "",
+  "format.in": "輸入",
+  "format.cache": "快取",
+  "format.out": "輸出",
+  "format.tok": "tok",
+  "format.tokPerSec": "tok/s",
+  "format.justNow": "剛剛",
+  "format.ago": "前",
+
+  // Init
+  "init.initializing": "[claude-hud] 正在初始化...",
+  "init.macosNote":
+    "[claude-hud] 注意：在 macOS 上，您可能需要重啟 Claude Code 才能顯示 HUD。",
+};

--- a/tests/i18n.test.js
+++ b/tests/i18n.test.js
@@ -158,3 +158,42 @@ test("mergeConfig accepts zh-Hans as valid language", () => {
   const config = mergeConfig({ language: "zh-Hans" });
   assert.equal(config.language, "zh-Hans");
 });
+
+test("t() returns Traditional Chinese strings for zh-Hant", () => {
+  setLanguage("zh-Hant");
+  assert.equal(t("label.context"), "上下文佔用");
+  assert.equal(t("label.usage"), "五小時上限");
+  assert.equal(t("label.weekly"), "每週使用量");
+  assert.equal(t("label.approxRam"), "記憶體用量");
+  assert.equal(t("status.limitReached"), "已達上限");
+  assert.equal(t("status.allTodosComplete"), "全部完成");
+  assert.equal(t("format.in"), "輸入");
+  assert.equal(t("format.out"), "輸出");
+  setLanguage("en");
+});
+
+test("getCanonicalLanguage resolves zh-Hant to zh-Hant", () => {
+  setLanguage("zh-Hant");
+  assert.equal(getCanonicalLanguage(), "zh-Hant");
+  setLanguage("en");
+});
+
+test("getCanonicalLanguage resolves zh-TW alias to zh-Hant", () => {
+  setLanguage("zh-TW");
+  assert.equal(getCanonicalLanguage(), "zh-Hant");
+  assert.equal(t("label.usage"), "五小時上限");
+  setLanguage("en");
+});
+
+test("isCjkLanguage returns true for zh-Hant and zh-TW", () => {
+  setLanguage("zh-Hant");
+  assert.equal(isCjkLanguage(), true);
+  setLanguage("zh-TW");
+  assert.equal(isCjkLanguage(), true);
+  setLanguage("en");
+});
+
+test("mergeConfig accepts zh-Hant and zh-TW as valid languages", () => {
+  assert.equal(mergeConfig({ language: "zh-Hant" }).language, "zh-Hant");
+  assert.equal(mergeConfig({ language: "zh-TW" }).language, "zh-TW");
+});


### PR DESCRIPTION
Adds a Traditional Chinese (`zh-Hant`) locale, using Taiwan terminology, on top of the upstream BCP-47 i18n infrastructure.

What changed:
- `src/i18n/types.ts`: add `zh-Hant` and `zh-TW` to the `Language` union.
- `src/i18n/zh-Hant.ts`: new locale file mirroring the full `MessageKey` set.
- `src/i18n/index.ts`: register `zh-Hant` in the canonical table and locales map; accept `zh-TW` as a region alias resolving to `zh-Hant`; extend `isCjkLanguage()`.
- `src/config.ts`: accept `zh-Hant` and `zh-TW` in `validateLanguage`.
- `tests/i18n.test.js`: coverage for the new locale, canonical resolution, the `zh-TW` alias, and config validation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmHQ1Zp8FAe6KqD1rrtCjH)_