### PR TITLE
override: localize session duration label and units

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -15,6 +15,7 @@ export const en: Messages = {
   "label.sessionStarted": "Started",
   "label.lastReply": "Last reply",
   "label.advisor": "Advisor",
+  "label.duration": "",
 
   // Status
   "status.limitReached": "Limit reached",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -13,6 +13,7 @@ export type MessageKey =
   | "label.sessionStarted"
   | "label.lastReply"
   | "label.advisor"
+  | "label.duration"
   // Status
   | "status.limitReached"
   | "status.allTodosComplete"

--- a/src/i18n/zh-Hans.ts
+++ b/src/i18n/zh-Hans.ts
@@ -15,6 +15,7 @@ export const zhHans: Messages = {
   "label.sessionStarted": "开始",
   "label.lastReply": "上次回复",
   "label.advisor": "顾问",
+  "label.duration": "",
 
   // Status
   "status.limitReached": "已达上限",

--- a/src/i18n/zh-Hant.ts
+++ b/src/i18n/zh-Hant.ts
@@ -15,6 +15,7 @@ export const zhHant: Messages = {
   "label.sessionStarted": "工作階段開始",
   "label.lastReply": "上次回覆",
   "label.advisor": "顧問",
+  "label.duration": "執行時間",
 
   // Status
   "status.limitReached": "已達上限",

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import { getMemoryUsage } from "./memory.js";
 import { resolveEffortLevel } from "./effort.js";
 import { applyContextWindowFallback } from "./context-cache.js";
 import { getUsageFromExternalSnapshot, writeExternalUsageSnapshot } from "./external-usage.js";
-import { setLanguage, t } from "./i18n/index.js";
+import { setLanguage, t, getCanonicalLanguage } from "./i18n/index.js";
 import type { RenderContext } from "./types.js";
 
 export { getUsageFromExternalSnapshot, writeExternalUsageSnapshot } from "./external-usage.js";
@@ -164,11 +164,20 @@ export function formatSessionDuration(
   const ms = now() - sessionStart.getTime();
   const mins = Math.floor(ms / 60000);
 
+  const hours = Math.floor(mins / 60);
+  const remainingMins = mins % 60;
+
+  // Traditional Chinese renders localized units (other languages keep the
+  // original compact English format).
+  if (getCanonicalLanguage() === "zh-Hant") {
+    if (mins < 1) return "< 1 分鐘";
+    if (mins < 60) return `${mins} 分鐘`;
+    return `${hours} 小時 ${remainingMins} 分鐘`;
+  }
+
   if (mins < 1) return "<1m";
   if (mins < 60) return `${mins}m`;
 
-  const hours = Math.floor(mins / 60);
-  const remainingMins = mins % 60;
   return `${hours}h ${remainingMins}m`;
 }
 

--- a/src/render/lines/project.ts
+++ b/src/render/lines/project.ts
@@ -173,7 +173,11 @@ export function renderProjectLine(ctx: RenderContext): string | null {
   }
 
   if (display?.showDuration !== false && ctx.sessionDuration) {
-    parts.push(label(`⏱️  ${ctx.sessionDuration}`, colors));
+    const durationLabel = t('label.duration');
+    const durationText = durationLabel
+      ? `⏱️ ${durationLabel}：${ctx.sessionDuration}`
+      : `⏱️  ${ctx.sessionDuration}`;
+    parts.push(label(durationText, colors));
   }
 
   const costEstimate = renderCostEstimate(ctx);

--- a/src/render/session-line.ts
+++ b/src/render/session-line.ts
@@ -286,7 +286,11 @@ export function renderSessionLine(ctx: RenderContext): string {
   }
 
   if (display?.showDuration !== false && ctx.sessionDuration) {
-    parts.push(label(`⏱️  ${ctx.sessionDuration}`, colors));
+    const durationLabel = t('label.duration');
+    const durationText = durationLabel
+      ? `⏱️ ${durationLabel}：${ctx.sessionDuration}`
+      : `⏱️  ${ctx.sessionDuration}`;
+    parts.push(label(durationText, colors));
   }
 
   const sessionTimeLine = renderSessionTimeLine(ctx);

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -120,6 +120,31 @@ test("formatSessionDuration uses Date.now by default", () => {
   }
 });
 
+test("formatSessionDuration localizes units for zh-Hant", () => {
+  setLanguage("zh-Hant");
+  const start = new Date(0);
+  try {
+    assert.equal(formatSessionDuration(start, () => 30 * 1000), "< 1 分鐘");
+    assert.equal(formatSessionDuration(start, () => 5 * 60 * 1000), "5 分鐘");
+    assert.equal(
+      formatSessionDuration(start, () => 2 * 60 * 60 * 1000 + 5 * 60 * 1000),
+      "2 小時 5 分鐘",
+    );
+  } finally {
+    setLanguage("en");
+  }
+});
+
+test("formatSessionDuration keeps English format for zh-Hans", () => {
+  setLanguage("zh-Hans");
+  const start = new Date(0);
+  try {
+    assert.equal(formatSessionDuration(start, () => 5 * 60 * 1000), "5m");
+  } finally {
+    setLanguage("en");
+  }
+});
+
 test("main logs an error when dependencies throw", async () => {
   const logs = [];
 


### PR DESCRIPTION
Localizes the session-duration display for Traditional Chinese while keeping the original compact format for all other languages.

What changed:
- `src/i18n/types.ts` + locales: add a `label.duration` key (`en`/`zh-Hans` empty = original/none, `zh-Hant` = `執行時間`).
- `src/index.ts`: `formatSessionDuration` renders localized units for `zh-Hant` (`< 1 分鐘`, `{n} 分鐘`, `{h} 小時 {m} 分鐘`), gated on `getCanonicalLanguage()`; other languages unchanged.
- `src/render/session-line.ts` + `src/render/lines/project.ts`: the `⏱️` segment uses `label.duration`, so Traditional shows `⏱️ 執行時間：…` and other languages keep `⏱️  …`.
- `tests/index.test.js`: coverage for the localized units and the unchanged Simplified/English format.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmHQ1Zp8FAe6KqD1rrtCjH)_