### PR TITLE
override: split weekly usage into its own always-visible element

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -21,7 +21,7 @@ export type GitBranchOverflowMode = 'truncate' | 'wrap';
 export type ModelFormatMode = 'full' | 'compact' | 'short';
 export type TimeFormatMode = 'relative' | 'absolute' | 'both' | 'elapsed' | 'elapsedAndAbsolute';
 export type CustomLinePosition = 'first' | 'last';
-export type HudElement = 'project' | 'addedDirs' | 'context' | 'usage' | 'promptCache' | 'memory' | 'environment' | 'tools' | 'agents' | 'todos' | 'sessionTime';
+export type HudElement = 'project' | 'addedDirs' | 'context' | 'usage' | 'weeklyUsage' | 'promptCache' | 'memory' | 'environment' | 'tools' | 'agents' | 'todos' | 'sessionTime';
 
 export type AddedDirsLayout = 'inline' | 'line';
 export type HudColorName =
@@ -58,6 +58,7 @@ export const DEFAULT_ELEMENT_ORDER: HudElement[] = [
   'addedDirs',
   'context',
   'usage',
+  'weeklyUsage',
   'promptCache',
   'memory',
   'environment',
@@ -67,9 +68,9 @@ export const DEFAULT_ELEMENT_ORDER: HudElement[] = [
   'sessionTime',
 ];
 
-export const DEFAULT_MERGE_GROUPS: HudElement[][] = [
-  ['context', 'usage'],
-];
+// Weekly usage is an independent, always-visible element, so context, usage,
+// and weeklyUsage each render on their own line by default (no merge group).
+export const DEFAULT_MERGE_GROUPS: HudElement[][] = [];
 
 const KNOWN_ELEMENTS = new Set<HudElement>(DEFAULT_ELEMENT_ORDER);
 

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -13,6 +13,7 @@ import {
   renderEnvironmentLine,
   renderPromptCacheLine,
   renderUsageLine,
+  renderWeeklyUsageLine,
   renderMemoryLine,
   renderSessionTokensLine,
   renderSessionTimeLine,
@@ -387,6 +388,8 @@ function renderElementLine(
       return renderIdentityLine(ctx, alignProgressLabels);
     case 'usage':
       return renderUsageLine(ctx, alignProgressLabels);
+    case 'weeklyUsage':
+      return renderWeeklyUsageLine(ctx, alignProgressLabels);
     case 'promptCache':
       return renderPromptCacheLine(ctx);
     case 'memory':

--- a/src/render/lines/index.ts
+++ b/src/render/lines/index.ts
@@ -3,7 +3,7 @@ export { renderProjectLine, renderGitFilesLine } from './project.js';
 export { renderAddedDirsLine } from './added-dirs.js';
 export { renderEnvironmentLine } from './environment.js';
 export { renderPromptCacheLine, formatPromptCacheCountdown } from './prompt-cache.js';
-export { renderUsageLine } from './usage.js';
+export { renderUsageLine, renderWeeklyUsageLine } from './usage.js';
 export { renderMemoryLine } from './memory.js';
 export { renderSessionTokensLine } from './session-tokens.js';
 export { renderSessionTimeLine } from './session-time.js';

--- a/src/render/lines/usage.ts
+++ b/src/render/lines/usage.ts
@@ -62,50 +62,22 @@ export function renderUsageLine(
 
   const threshold = display?.usageThreshold ?? 0;
   const fiveHour = ctx.usageData.fiveHour;
-  const sevenDay = ctx.usageData.sevenDay;
 
-  const effectiveUsage = Math.max(fiveHour ?? 0, sevenDay ?? 0);
-  if (effectiveUsage < threshold) {
+  // Weekly usage is rendered by the independent weeklyUsage element.
+  if (fiveHour === null) {
     return null;
   }
 
-  const sevenDayThreshold = display?.sevenDayThreshold ?? 80;
+  if (fiveHour < threshold) {
+    return null;
+  }
 
   if (usageCompact) {
-    const fiveHourPart = fiveHour !== null
-      ? formatCompactWindowPart("5h", fiveHour, ctx.usageData.fiveHourResetAt, FIVE_HOUR_WINDOW_MS, timeFormat, colors, usageValueMode)
-      : null;
-    const sevenDayPart = (sevenDay !== null && (fiveHour === null || sevenDay >= sevenDayThreshold))
-      ? formatCompactWindowPart("7d", sevenDay, ctx.usageData.sevenDayResetAt, SEVEN_DAY_WINDOW_MS, timeFormat, colors, usageValueMode)
-      : null;
-
-    if (fiveHourPart && sevenDayPart) {
-      return `${fiveHourPart} | ${sevenDayPart}`;
-    }
-    return fiveHourPart ?? sevenDayPart ?? null;
+    return formatCompactWindowPart("5h", fiveHour, ctx.usageData.fiveHourResetAt, FIVE_HOUR_WINDOW_MS, timeFormat, colors, usageValueMode);
   }
 
   const usageBarEnabled = display?.usageBarEnabled ?? true;
   const barWidth = getAdaptiveBarWidth();
-
-  if (fiveHour === null && sevenDay !== null) {
-    const weeklyOnlyPart = formatUsageWindowPart({
-      label: t("label.weekly"),
-      labelKey: "label.weekly",
-      percent: sevenDay,
-      resetAt: ctx.usageData.sevenDayResetAt,
-      windowMs: SEVEN_DAY_WINDOW_MS,
-      colors,
-      usageBarEnabled,
-      barWidth,
-      timeFormat,
-      showResetLabel,
-      forceLabel: true,
-      alignLabels,
-      usageValueMode,
-    });
-    return `${usageLabel} ${weeklyOnlyPart}`;
-  }
 
   const fiveHourPart = formatUsageWindowPart({
     label: "5h",
@@ -120,26 +92,61 @@ export function renderUsageLine(
     usageValueMode,
   });
 
-  if (sevenDay !== null && sevenDay >= sevenDayThreshold) {
-    const sevenDayPart = formatUsageWindowPart({
-      label: t("label.weekly"),
-      labelKey: "label.weekly",
-      percent: sevenDay,
-      resetAt: ctx.usageData.sevenDayResetAt,
-      windowMs: SEVEN_DAY_WINDOW_MS,
-      colors,
-      usageBarEnabled,
-      barWidth,
-      timeFormat,
-      showResetLabel,
-      forceLabel: true,
-      alignLabels,
-      usageValueMode,
-    });
-    return `${usageLabel} ${fiveHourPart} | ${sevenDayPart}`;
+  return `${usageLabel} ${fiveHourPart}`;
+}
+
+export function renderWeeklyUsageLine(
+  ctx: RenderContext,
+  alignLabels = false,
+): string | null {
+  const display = ctx.config?.display;
+  const colors = ctx.config?.colors;
+
+  if (display?.showUsage === false) {
+    return null;
   }
 
-  return `${usageLabel} ${fiveHourPart}`;
+  if (!ctx.usageData) {
+    return null;
+  }
+
+  if (shouldHideUsage(ctx.stdin)) {
+    return null;
+  }
+
+  const sevenDay = ctx.usageData.sevenDay;
+  if (sevenDay === null) {
+    return null;
+  }
+
+  const timeFormat = normalizeTimeFormat(display?.timeFormat);
+  const showResetLabel = display?.showResetLabel ?? true;
+  const usageCompact = display?.usageCompact ?? false;
+  const usageValueMode = display?.usageValue ?? 'percent';
+
+  // Always visible: the sevenDayThreshold gate is intentionally not applied.
+  if (usageCompact) {
+    return formatCompactWindowPart("7d", sevenDay, ctx.usageData.sevenDayResetAt, SEVEN_DAY_WINDOW_MS, timeFormat, colors, usageValueMode);
+  }
+
+  const usageBarEnabled = display?.usageBarEnabled ?? true;
+  const barWidth = getAdaptiveBarWidth();
+
+  return formatUsageWindowPart({
+    label: t("label.weekly"),
+    labelKey: "label.weekly",
+    percent: sevenDay,
+    resetAt: ctx.usageData.sevenDayResetAt,
+    windowMs: SEVEN_DAY_WINDOW_MS,
+    colors,
+    usageBarEnabled,
+    barWidth,
+    timeFormat,
+    showResetLabel,
+    forceLabel: true,
+    alignLabels,
+    usageValueMode,
+  });
 }
 
 function formatCompactWindowPart(

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -488,10 +488,23 @@ test('mergeConfig defaults elementOrder to the full expanded layout', () => {
   assert.deepEqual(config.elementOrder, DEFAULT_ELEMENT_ORDER);
 });
 
-test('mergeConfig defaults mergeGroups to context and usage', () => {
+test('mergeConfig defaults mergeGroups to empty so usage windows render separately', () => {
   const config = mergeConfig({});
   assert.deepEqual(config.display.mergeGroups, DEFAULT_MERGE_GROUPS);
   assert.deepEqual(DEFAULT_CONFIG.display.mergeGroups, DEFAULT_MERGE_GROUPS);
+  assert.deepEqual(DEFAULT_MERGE_GROUPS, []);
+});
+
+test('default element order includes weeklyUsage right after usage', () => {
+  const usageIndex = DEFAULT_ELEMENT_ORDER.indexOf('usage');
+  const weeklyIndex = DEFAULT_ELEMENT_ORDER.indexOf('weeklyUsage');
+  assert.ok(usageIndex >= 0, 'usage should be present');
+  assert.equal(weeklyIndex, usageIndex + 1, 'weeklyUsage should immediately follow usage');
+});
+
+test('mergeConfig accepts weeklyUsage in elementOrder', () => {
+  const config = mergeConfig({ elementOrder: ['project', 'usage', 'weeklyUsage', 'context'] });
+  assert.deepEqual(config.elementOrder, ['project', 'usage', 'weeklyUsage', 'context']);
 });
 
 test('mergeConfig preserves explicit empty mergeGroups to disable merged lines', () => {

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -12,7 +12,7 @@ import { renderPromptCacheLine } from '../dist/render/lines/prompt-cache.js';
 import { renderToolsLine, shortenToolName } from '../dist/render/tools-line.js';
 import { renderAgentsLine } from '../dist/render/agents-line.js';
 import { renderTodosLine } from '../dist/render/todos-line.js';
-import { renderUsageLine } from '../dist/render/lines/usage.js';
+import { renderUsageLine, renderWeeklyUsageLine } from '../dist/render/lines/usage.js';
 import { renderMemoryLine } from '../dist/render/lines/memory.js';
 import { renderIdentityLine } from '../dist/render/lines/identity.js';
 import { renderEnvironmentLine } from '../dist/render/lines/environment.js';
@@ -1644,8 +1644,11 @@ test('renderUsageLine shows 7d reset countdown in text-only mode', () => {
 
   const line = stripAnsi(renderUsageLine(ctx));
   assert.ok(line.includes('5h 45%'), `should include 5h text-only usage: ${line}`);
-  assert.ok(line.includes('Weekly 85%'), `should include 7d text-only usage: ${line}`);
-  assert.ok(line.includes('(resets in 1d 4h)'), `should include 7d reset countdown in text-only mode: ${line}`);
+  assert.ok(!line.includes('Weekly'), `usage line should no longer embed weekly usage: ${line}`);
+
+  const weeklyLine = stripAnsi(renderWeeklyUsageLine(ctx));
+  assert.ok(weeklyLine.includes('Weekly 85%'), `should include 7d text-only usage: ${weeklyLine}`);
+  assert.ok(weeklyLine.includes('(resets in 1d 4h)'), `should include 7d reset countdown in text-only mode: ${weeklyLine}`);
 });
 
 test('renderUsageLine supports remaining-based usage display with used-percent colors', () => {
@@ -1672,9 +1675,12 @@ test('renderUsageLine supports remaining-based usage display with used-percent c
     line.includes('\x1b[36m75%\x1b[0m'),
     `expected remaining 5h usage with normal usage color, got: ${JSON.stringify(line)}`,
   );
+
+  const weeklyLine = renderWeeklyUsageLine(ctx);
+  assert.ok(weeklyLine, 'should render weekly usage line');
   assert.ok(
-    line.includes('\x1b[35m15%\x1b[0m'),
-    `expected remaining weekly usage with used-percent warning color, got: ${JSON.stringify(line)}`,
+    weeklyLine.includes('\x1b[35m15%\x1b[0m'),
+    `expected remaining weekly usage with used-percent warning color, got: ${JSON.stringify(weeklyLine)}`,
   );
 });
 
@@ -1707,14 +1713,13 @@ test('renderUsageLine can hide reset label in text-only mode', () => {
     sevenDayResetAt: resetTime,
   };
 
-  const line = stripAnsi(renderUsageLine(ctx));
+  const line = stripAnsi(renderWeeklyUsageLine(ctx));
   assert.ok(line.includes('(1d 4h)'), `should include bare countdown when reset label is hidden: ${line}`);
   assert.ok(!line.includes('resets in'), `should omit reset label when disabled: ${line}`);
 });
 
-test('renderUsageLine translates weekly label when Chinese is enabled', () => {
+test('renderWeeklyUsageLine translates weekly label when Chinese is enabled', () => {
   const ctx = baseContext();
-  ctx.config.display.sevenDayThreshold = 80;
   ctx.usageData = {
     planName: 'Pro',
     fiveHour: 45,
@@ -1725,7 +1730,7 @@ test('renderUsageLine translates weekly label when Chinese is enabled', () => {
 
   setLanguage('zh');
   try {
-    const line = stripAnsi(renderUsageLine(ctx) ?? '');
+    const line = stripAnsi(renderWeeklyUsageLine(ctx) ?? '');
     assert.ok(line.includes('本周'));
     assert.ok(line.includes('重置剩余'));
   } finally {
@@ -1733,11 +1738,10 @@ test('renderUsageLine translates weekly label when Chinese is enabled', () => {
   }
 });
 
-test('renderUsageLine shows 7d reset countdown in bar mode when above threshold', () => {
+test('renderWeeklyUsageLine shows 7d reset countdown in bar mode (always visible)', () => {
   const ctx = baseContext();
   const resetTime = new Date(Date.now() + (28 * 60 * 60 * 1000)); // 1d 4h from now
   ctx.config.display.usageBarEnabled = true;
-  ctx.config.display.sevenDayThreshold = 80;
   ctx.usageData = {
     planName: 'Pro',
     fiveHour: 45,
@@ -1746,19 +1750,18 @@ test('renderUsageLine shows 7d reset countdown in bar mode when above threshold'
     sevenDayResetAt: resetTime,
   };
 
-  const line = stripAnsi(renderUsageLine(ctx));
-  assert.ok(line.includes('45%'), `should include 5h percentage in bar mode: ${line}`);
+  assert.ok(stripAnsi(renderUsageLine(ctx)).includes('45%'), 'usage line should include 5h percentage');
+  const line = stripAnsi(renderWeeklyUsageLine(ctx));
   assert.ok(line.includes('85%'), `should include 7d percentage: ${line}`);
   assert.ok(line.includes('(resets in 1d 4h)'), `should include 7d reset countdown in bar mode: ${line}`);
-  assert.ok(line.includes('|'), `should render both usage windows above the threshold: ${line}`);
+  assert.ok(line.includes('Weekly'), `should render the weekly label: ${line}`);
 });
 
-test('renderUsageLine can hide reset label in bar mode', () => {
+test('renderWeeklyUsageLine can hide reset label in bar mode', () => {
   const ctx = baseContext();
   const resetTime = new Date(Date.now() + (28 * 60 * 60 * 1000));
   ctx.config.display.usageBarEnabled = true;
   ctx.config.display.showResetLabel = false;
-  ctx.config.display.sevenDayThreshold = 80;
   ctx.usageData = {
     planName: 'Pro',
     fiveHour: 45,
@@ -1767,14 +1770,13 @@ test('renderUsageLine can hide reset label in bar mode', () => {
     sevenDayResetAt: resetTime,
   };
 
-  const line = stripAnsi(renderUsageLine(ctx));
+  const line = stripAnsi(renderWeeklyUsageLine(ctx));
   assert.ok(line.includes('(1d 4h)'), `should include bare countdown in bar mode: ${line}`);
   assert.ok(!line.includes('resets in'), `should omit reset label in bar mode when disabled: ${line}`);
 });
 
-test('renderUsageLine shows weekly-only usage without a ghost 5h section', () => {
+test('renderWeeklyUsageLine is shown below threshold while usage line hides weekly', () => {
   const ctx = baseContext();
-  ctx.config.display.sevenDayThreshold = 80;
   ctx.usageData = {
     planName: 'Pro',
     fiveHour: null,
@@ -1783,12 +1785,13 @@ test('renderUsageLine shows weekly-only usage without a ghost 5h section', () =>
     sevenDayResetAt: null,
   };
 
-  const line = stripAnsi(renderUsageLine(ctx));
-  assert.ok(line.includes('Usage'), `should render usage line: ${line}`);
-  assert.ok(!line.includes('5h'), `should not render a ghost 5h section: ${line}`);
-  assert.ok(line.includes('Weekly'), `should render the weekly window when it is the only usage value: ${line}`);
-  assert.ok(line.includes('13%'), `should render the weekly percentage: ${line}`);
-  assert.ok(!line.includes('|'), `should not render a separator for a missing 5h window: ${line}`);
+  // No five-hour data: the usage element renders nothing.
+  assert.equal(renderUsageLine(ctx), null);
+
+  const line = stripAnsi(renderWeeklyUsageLine(ctx));
+  assert.ok(line.includes('Weekly'), `should render the weekly window even when it is the only usage value: ${line}`);
+  assert.ok(line.includes('13%'), `should render the weekly percentage even below threshold: ${line}`);
+  assert.ok(!line.includes('5h'), `should not render a 5h section: ${line}`);
 });
 
 test('renderSessionLine displays limit reached warning', () => {
@@ -1889,8 +1892,11 @@ test('renderUsageLine uses custom usage palette overrides', () => {
   assert.ok(line, 'should render usage line');
   assert.ok(line.includes('\x1b[36m███'), `expected custom usage bar color, got: ${JSON.stringify(line)}`);
   assert.ok(line.includes('\x1b[36m25%\x1b[0m'), `expected custom usage percentage color, got: ${JSON.stringify(line)}`);
-  assert.ok(line.includes('\x1b[35m████████'), `expected custom usage warning color, got: ${JSON.stringify(line)}`);
-  assert.ok(line.includes('\x1b[35m80%\x1b[0m'), `expected custom usage warning percentage color, got: ${JSON.stringify(line)}`);
+
+  const weeklyLine = withTerminal(120, () => renderWeeklyUsageLine(ctx));
+  assert.ok(weeklyLine, 'should render weekly usage line');
+  assert.ok(weeklyLine.includes('\x1b[35m████████'), `expected custom usage warning color, got: ${JSON.stringify(weeklyLine)}`);
+  assert.ok(weeklyLine.includes('\x1b[35m80%\x1b[0m'), `expected custom usage warning percentage color, got: ${JSON.stringify(weeklyLine)}`);
 });
 
 test('quotaBar and coloredBar use custom barFilled and barEmpty characters', () => {
@@ -2441,7 +2447,8 @@ test('render expanded layout aligns progress labels only after wrapping merged l
     fiveHourResetAt: new Date(Date.now() + 90 * 60 * 1000),
     sevenDayResetAt: new Date(Date.now() + 4 * 24 * 60 * 60 * 1000),
   };
-  ctx.config.elementOrder = ['usage', 'context'];
+  ctx.config.elementOrder = ['usage', 'context', 'weeklyUsage'];
+  ctx.config.display.mergeGroups = [['context', 'usage']];
 
   const lines = withTerminal(24, () => captureRenderLines(ctx)).map(stripAnsi);
   const usageLine = lines.find((line) => line.includes('Usage'));
@@ -2450,9 +2457,9 @@ test('render expanded layout aligns progress labels only after wrapping merged l
 
   assert.ok(usageLine, `narrow terminals should keep the usage line visible: ${lines.join(' | ')}`);
   assert.ok(contextLine, `narrow terminals should keep the context line visible: ${lines.join(' | ')}`);
-  assert.ok(weeklyLine, `narrow terminals should keep the weekly segment visible: ${lines.join(' | ')}`);
+  assert.ok(weeklyLine, `the weekly element should render as its own line: ${lines.join(' | ')}`);
   assert.ok(usageLine.startsWith('Usage  '), `usage line should pad its label when stacked: ${usageLine}`);
-  assert.ok(weeklyLine.startsWith('Weekly '), `weekly label should pad when stacked: ${weeklyLine}`);
+  assert.ok(weeklyLine.startsWith('Weekly '), `weekly label should be followed by its value: ${weeklyLine}`);
   assert.ok(contextLine.startsWith('Context'), `context line should stay aligned with the padded usage label: ${contextLine}`);
 });
 
@@ -2636,7 +2643,7 @@ test('renderUsageLine rounds elapsed 7d window percentage', () => {
     sevenDayResetAt: new Date(now + 5.5 * 24 * 60 * 60 * 1000),
   };
 
-  const plain = stripAnsi(renderUsageLine(ctx));
+  const plain = stripAnsi(renderWeeklyUsageLine(ctx));
   assert.ok(plain.includes('Weekly 85% (21% elapsed)'), `expected rounded weekly elapsed percentage, got: ${plain}`);
 });
 


### PR DESCRIPTION
Makes weekly (7-day) usage an independent, always-visible HUD element instead of being embedded in the `usage` element behind the `sevenDayThreshold` gate.

What changed:
- `src/config.ts`: add `weeklyUsage` to the `HudElement` union; insert it right after `usage` in `DEFAULT_ELEMENT_ORDER`; set `DEFAULT_MERGE_GROUPS` to `[]` so context, usage, and weeklyUsage each render on their own line.
- `src/render/lines/usage.ts`: add `renderWeeklyUsageLine` (mirrors the five-hour pattern: label, bar, percentage, reset time) with no threshold gate; reduce `renderUsageLine` to handle only the five-hour window.
- `src/render/lines/index.ts` + `src/render/index.ts`: barrel-export the new renderer and add a `weeklyUsage` case to the element switch.
- Compact (session-line) weekly handling is intentionally left on the upstream threshold rules (used by the Lite preset).
- `tests/render.test.js` + `tests/config.test.js`: weekly assertions moved to `renderWeeklyUsageLine`; added coverage for the new element and default order/merge changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmHQ1Zp8FAe6KqD1rrtCjH)_