### PR TITLE
override: restrict the @claude workflow to the fork owner

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,10 +13,10 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' && github.event.comment.user.login == 'UnpxreTW' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && github.event.comment.user.login == 'UnpxreTW' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && github.event.review.user.login == 'UnpxreTW' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && github.event.issue.user.login == 'UnpxreTW' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Adds an actor gate to each of the four `@claude` trigger conditions in `.github/workflows/claude.yml` so only the fork owner can trigger the workflow. Each condition uses the actor object appropriate to its event and is checked before the existing `@claude` mention check:

- `issue_comment` → `github.event.comment.user.login == 'UnpxreTW'`
- `pull_request_review_comment` → `github.event.comment.user.login == 'UnpxreTW'`
- `pull_request_review` → `github.event.review.user.login == 'UnpxreTW'`
- `issues` → `github.event.issue.user.login == 'UnpxreTW'`

---
_Generated by [Claude Code](https://claude.ai/code/session_01MLWT6NTp1xyeXGK9Myp18D)_